### PR TITLE
[ENG-18] Add type aliases for little endian fields

### DIFF
--- a/interface/src/instructions/amount.rs
+++ b/interface/src/instructions/amount.rs
@@ -3,9 +3,9 @@ use static_assertions::const_assert_eq;
 use crate::{
     pack::{write_bytes, Pack},
     state::{
-        sector::{NonNilSectorIndex, NIL},
+        sector::{LeSectorIndex, NonNilSectorIndex, NIL},
         transmutable::Transmutable,
-        U32_SIZE, U64_SIZE,
+        LeU64,
     },
 };
 use core::mem::MaybeUninit;
@@ -13,11 +13,11 @@ use core::mem::MaybeUninit;
 #[repr(C)]
 pub struct AmountInstructionData {
     /// The amount to deposit or withdraw.
-    amount: [u8; U64_SIZE],
+    amount: LeU64,
     /// A hint as to which sector index the calling user is located in the sectors array.
     /// The getter for this field exposes it as an Option<NonNilSectorIndex>, where `NIL` as the
     /// hint is equivalent to None.
-    sector_index_hint: [u8; U32_SIZE],
+    sector_index_hint: LeSectorIndex,
 }
 
 impl AmountInstructionData {

--- a/interface/src/instructions/close.rs
+++ b/interface/src/instructions/close.rs
@@ -3,14 +3,17 @@ use static_assertions::const_assert_eq;
 use crate::{
     error::DropsetError,
     pack::{write_bytes, Pack},
-    state::{sector::NonNilSectorIndex, transmutable::Transmutable, U32_SIZE},
+    state::{
+        sector::{NonNilSectorIndex, LeSectorIndex},
+        transmutable::Transmutable,
+    },
 };
 use core::mem::MaybeUninit;
 
 #[repr(C)]
 pub struct CloseInstructionData {
     /// A hint as to which sector index the calling user is located in the sectors array.
-    sector_index_hint: [u8; U32_SIZE],
+    sector_index_hint: LeSectorIndex,
 }
 
 impl CloseInstructionData {

--- a/interface/src/instructions/num_sectors.rs
+++ b/interface/src/instructions/num_sectors.rs
@@ -2,13 +2,13 @@ use static_assertions::const_assert_eq;
 
 use crate::{
     pack::{write_bytes, Pack},
-    state::{transmutable::Transmutable, U16_SIZE},
+    state::{transmutable::Transmutable, LeU16},
 };
 use core::mem::MaybeUninit;
 
 #[repr(C)]
 pub struct NumSectorsInstructionData {
-    num_sectors: [u8; U16_SIZE],
+    num_sectors: LeU16,
 }
 
 impl NumSectorsInstructionData {

--- a/interface/src/state/mod.rs
+++ b/interface/src/state/mod.rs
@@ -5,5 +5,12 @@ pub const U16_SIZE: usize = core::mem::size_of::<u16>();
 pub const U32_SIZE: usize = core::mem::size_of::<u32>();
 pub const U64_SIZE: usize = core::mem::size_of::<u64>();
 
+/// Alias type for a u16 stored as little-endian bytes.
+pub type LeU16 = [u8; U16_SIZE];
+/// Alias type for a u32 stored as little-endian bytes.
+pub type LeU32 = [u8; U32_SIZE];
+/// Alias type for a u64 stored as little-endian bytes.
+pub type LeU64 = [u8; U64_SIZE];
+
 pub const SYSTEM_PROGRAM_ID: pinocchio::pubkey::Pubkey =
     pinocchio_pubkey::pubkey!("11111111111111111111111111111111");

--- a/interface/src/state/sector.rs
+++ b/interface/src/state/sector.rs
@@ -9,6 +9,9 @@ pub const SECTOR_SIZE: usize = 72;
 /// of 10 megabytes would mean the max sector index (~10.5 million) is still far less than u32::MAX.
 pub const NIL: SectorIndex = SectorIndex(u32::MAX);
 
+// An alias type for readability.
+pub type LeSectorIndex = [u8; U32_SIZE];
+
 #[repr(transparent)]
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// A stride-based index into an array of sectors.

--- a/interface/src/state/transmutable.rs
+++ b/interface/src/state/transmutable.rs
@@ -23,6 +23,9 @@ pub unsafe trait Transmutable: Sized {
 
     /// Validates that `bytes` represents a valid `Self`.
     ///
+    /// Note that this does *not* check for initialized data, only that casting `bytes` to `Self`
+    /// will not result in undefined behavior (invalid enum variants, bools from u8 bytes, etc).
+    ///
     /// Called after length checks, so implementors may assume `bytes.len() == Self::LEN`.
     /// Should be marked `#[inline(always)]` in implementations for optimal performance.
     fn validate_bit_patterns(bytes: &[u8]) -> DropsetResult;


### PR DESCRIPTION
# Description

Fairly straightforward, aliases little endian integer fields to a type that's more descriptive than `[u8; {const}]`