### PR TITLE
[ENG-23] Add register market instruction, context, and account validation

### DIFF
--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -13,6 +13,11 @@ pub enum DropsetError {
     UnalignedData,
     UnallocatedAccountData,
     UserAlreadyExists,
+    NotEnoughAccountKeys,
+    InvalidTokenProgram,
+    AlreadyInitializedAccount,
+    NotOwnedBySystemProgram,
+    AddressDerivationFailed,
 }
 
 impl From<DropsetError> for ProgramError {
@@ -35,6 +40,11 @@ impl From<DropsetError> for &'static str {
             DropsetError::UnalignedData => "Account data is unaligned",
             DropsetError::UnallocatedAccountData => "Account data hasn't been properly allocated",
             DropsetError::UserAlreadyExists => "User already has an existing seat",
+            DropsetError::NotEnoughAccountKeys => "Not enough account keys were provided",
+            DropsetError::InvalidTokenProgram => "Invalid token program ID",
+            DropsetError::AlreadyInitializedAccount => "Account has already been initialized",
+            DropsetError::NotOwnedBySystemProgram => "Account is not owned by the system program",
+            DropsetError::AddressDerivationFailed => "PDA derivation failed",
         }
     }
 }

--- a/interface/src/lib.rs
+++ b/interface/src/lib.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod instructions;
 pub mod pack;
 pub mod state;
+pub mod utils;
 
 pub mod program {
     pinocchio_pubkey::declare_id!("TESTnXwv2eHoftsSd5NEdpH4zEu7XRC8jviuoNPdB2Q");

--- a/interface/src/state/market.rs
+++ b/interface/src/state/market.rs
@@ -34,7 +34,7 @@ impl<'a> MarketRef<'a> {
     ///
     /// # Safety
     ///
-    /// Caller guarantees that `MARKET_HEADER_SIZE <= data.len()`.
+    /// Caller guarantees that `data.len() >= MARKET_HEADER_SIZE`.
     pub unsafe fn from_bytes(data: &'a [u8]) -> Self {
         let (header_bytes, sectors) = data.split_at_unchecked(MarketHeader::LEN);
         // Safety: MarketHeaders are valid for all bit patterns.
@@ -52,7 +52,7 @@ impl<'a> MarketRefMut<'a> {
     ///
     /// # Safety
     ///
-    /// Caller guarantees that `MARKET_HEADER_SIZE <= data.len()`.
+    /// Caller guarantees that `data.len() >= MARKET_HEADER_SIZE`.
     pub unsafe fn from_bytes_mut(data: &'a mut [u8]) -> Self {
         let (header_bytes, sectors) = data.split_at_mut_unchecked(MarketHeader::LEN);
         // Safety: MarketHeaders are valid (no undefined behavior) for all bit patterns.

--- a/interface/src/utils.rs
+++ b/interface/src/utils.rs
@@ -1,0 +1,9 @@
+use pinocchio::{
+    account_info::AccountInfo,
+    pubkey::{pubkey_eq, Pubkey},
+};
+
+#[inline(always)]
+pub fn owned_by(info: &AccountInfo, expected_owner: &Pubkey) -> bool {
+    pubkey_eq(info.owner(), expected_owner)
+}

--- a/program/src/context/mod.rs
+++ b/program/src/context/mod.rs
@@ -1,0 +1,1 @@
+pub mod register_market_context;

--- a/program/src/context/register_market_context.rs
+++ b/program/src/context/register_market_context.rs
@@ -1,0 +1,53 @@
+use dropset_interface::error::DropsetError;
+use pinocchio::account_info::AccountInfo;
+
+use crate::validation::{
+    token_program_info::TokenProgramInfo, uninitialized_account_info::UninitializedAccountInfo,
+};
+
+#[derive(Clone)]
+pub struct RegisterMarketContext<'a> {
+    pub user: &'a AccountInfo,
+    pub market_account: UninitializedAccountInfo<'a>,
+    pub base_mint: &'a AccountInfo,
+    pub quote_mint: &'a AccountInfo,
+    pub base_market_ata: &'a AccountInfo,
+    pub quote_market_ata: &'a AccountInfo,
+    pub base_token_program: TokenProgramInfo<'a>,
+    pub quote_token_program: TokenProgramInfo<'a>,
+    pub system_program: &'a AccountInfo,
+}
+
+impl<'a> RegisterMarketContext<'a> {
+    pub fn load(accounts: &'a [AccountInfo]) -> Result<RegisterMarketContext<'a>, DropsetError> {
+        let [user, market_account, base_mint, quote_mint, base_market_ata, quote_market_ata, base_token_program, quote_token_program, system_program] =
+            accounts
+        else {
+            return Err(DropsetError::NotEnoughAccountKeys);
+        };
+
+        // Since the market PDA and both of its associated token accounts are created atomically
+        // during market registration, all derivations are guaranteed to be correct if the
+        // transaction succeeds. The two mint accounts are also guaranteed to be different, since
+        // the non-idempotent ATA creation instruction would fail on the second invocation.
+        // Thus there is no need to check ownership, address derivations, or account data here, only
+        // that the token programs provided are valid and that `market_account` is uninitialized.
+        let market_account = UninitializedAccountInfo::new(market_account)?;
+        // These checks are necessary since an antagonistic caller could substitute these with
+        // malicious programs with identical interfaces as the token programs.
+        let base_token_program = TokenProgramInfo::new(base_token_program)?;
+        let quote_token_program = TokenProgramInfo::new(quote_token_program)?;
+
+        Ok(Self {
+            user,
+            market_account,
+            base_mint,
+            quote_mint,
+            base_market_ata,
+            quote_market_ata,
+            base_token_program,
+            quote_token_program,
+            system_program,
+        })
+    }
+}

--- a/program/src/instructions/register_market.rs
+++ b/program/src/instructions/register_market.rs
@@ -1,8 +1,60 @@
-use pinocchio::{account_info::AccountInfo, ProgramResult};
+use dropset_interface::{
+    error::DropsetError,
+    instructions::num_sectors::NumSectorsInstructionData,
+    state::{market_header::MarketHeader, sector::SECTOR_SIZE, transmutable::Transmutable},
+};
+use pinocchio::{
+    account_info::AccountInfo,
+    pubkey::try_find_program_address,
+    sysvars::{rent::Rent, Sysvar},
+    ProgramResult,
+};
 
-pub fn process_register_market(
-    _accounts: &[AccountInfo],
-    _instruction_data: &[u8],
-) -> ProgramResult {
+use crate::{
+    context::register_market_context::RegisterMarketContext,
+    market_signer,
+    shared::{
+        market_operations::initialize_market_account_data,
+        token_utils::create_token_accounts::{self},
+    },
+};
+
+pub fn process_register_market(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
+    let num_sectors = NumSectorsInstructionData::load(instruction_data)?.num_sectors();
+    let ctx = RegisterMarketContext::load(accounts)?;
+
+    // It's not necessary to check the returned PDA here because `CreateAccount` will fail if the
+    // market account info's pubkey doesn't match.
+    let (_pda, market_bump) =
+        try_find_program_address(&[ctx.base_mint.key(), ctx.quote_mint.key()], &crate::ID)
+            .ok_or(DropsetError::AddressDerivationFailed)?;
+
+    // Create the program derived market account.
+    let account_space = MarketHeader::LEN + SECTOR_SIZE * (num_sectors as usize);
+    let lamports_required = Rent::get()?.minimum_balance(account_space);
+    pinocchio_system::instructions::CreateAccount {
+        from: ctx.user,
+        to: ctx.market_account.info,
+        lamports: lamports_required,
+        space: account_space as u64,
+        owner: &crate::ID,
+    }
+    .invoke_signed(&[market_signer!(
+        ctx.base_mint.key(),
+        ctx.quote_mint.key(),
+        market_bump
+    )])?;
+
+    // Create the market's base and quote associated token accounts.
+    create_token_accounts::create_atas(&ctx)?;
+
+    initialize_market_account_data(
+        // Safety: Single mutable borrow of the market account data for the init call.
+        unsafe { ctx.market_account.info.borrow_mut_data_unchecked() },
+        ctx.base_mint.key(),
+        ctx.quote_mint.key(),
+        market_bump,
+    )?;
+
     Ok(())
 }

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -2,9 +2,11 @@
 
 use pinocchio::{no_allocator, nostd_panic_handler, program_entrypoint};
 
+mod context;
 mod entrypoint;
 mod instructions;
 mod shared;
+mod validation;
 
 program_entrypoint!(entrypoint::process_instruction);
 no_allocator!();

--- a/program/src/shared/mod.rs
+++ b/program/src/shared/mod.rs
@@ -1,1 +1,3 @@
 pub mod market_operations;
+pub mod seeds;
+pub mod token_utils;

--- a/program/src/shared/seeds.rs
+++ b/program/src/shared/seeds.rs
@@ -1,0 +1,24 @@
+pub mod market {
+    pub const MARKET_SEED_STR: &[u8] = b"market";
+}
+
+#[macro_export]
+/// # Example
+///
+/// ```
+/// use dropset::market_signer;
+/// use pinocchio::instruction::Signer;
+///
+/// let bump: u8 = 0x10;
+/// let signer: Signer = crate::market_signer!(base_mint, quote_mint, bump);
+/// ```
+macro_rules! market_signer {
+    ( $base_mint:expr, $quote_mint:expr, $bump:expr ) => {
+        pinocchio::instruction::Signer::from(&pinocchio::seeds!(
+            $base_mint.as_ref(),
+            $quote_mint.as_ref(),
+            $crate::shared::seeds::market::MARKET_SEED_STR,
+            &[$bump]
+        ))
+    };
+}

--- a/program/src/shared/token_utils/create_token_accounts.rs
+++ b/program/src/shared/token_utils/create_token_accounts.rs
@@ -1,0 +1,33 @@
+use pinocchio::ProgramResult;
+
+use crate::context::register_market_context::RegisterMarketContext;
+
+/// Creates the base and quote associated token accounts for a market.
+pub fn create_atas(ctx: &RegisterMarketContext) -> ProgramResult {
+    for (mint, ata, token_program) in [
+        (
+            ctx.base_mint,
+            ctx.base_market_ata,
+            ctx.base_token_program.info,
+        ),
+        (
+            ctx.quote_mint,
+            ctx.quote_market_ata,
+            ctx.quote_token_program.info,
+        ),
+    ] {
+        // Create the associated token accounts with the non-idempotent instruction to ensure that
+        // passing duplicate mint accounts fails.
+        pinocchio_associated_token_account::instructions::Create {
+            funding_account: ctx.user,
+            account: ata,
+            wallet: ctx.market_account.info,
+            mint,
+            system_program: ctx.system_program,
+            token_program,
+        }
+        .invoke()?;
+    }
+
+    Ok(())
+}

--- a/program/src/shared/token_utils/mod.rs
+++ b/program/src/shared/token_utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod create_token_accounts;

--- a/program/src/validation/mod.rs
+++ b/program/src/validation/mod.rs
@@ -1,0 +1,2 @@
+pub mod token_program_info;
+pub mod uninitialized_account_info;

--- a/program/src/validation/token_program_info.rs
+++ b/program/src/validation/token_program_info.rs
@@ -1,0 +1,22 @@
+use dropset_interface::error::DropsetError;
+use pinocchio::{account_info::AccountInfo, pubkey::pubkey_eq};
+
+#[derive(Clone)]
+pub struct TokenProgramInfo<'a> {
+    pub info: &'a AccountInfo,
+    /// To avoid pubkey comparisons later, store whether or not this is the base or 2022 program.
+    pub is_spl_token: bool,
+}
+
+impl<'a> TokenProgramInfo<'a> {
+    #[inline(always)]
+    pub fn new(info: &'a AccountInfo) -> Result<TokenProgramInfo<'a>, DropsetError> {
+        let is_spl_token = pubkey_eq(info.key(), &pinocchio_token::ID);
+
+        if !is_spl_token && !pubkey_eq(info.key(), &pinocchio_token_2022::ID) {
+            return Err(DropsetError::InvalidTokenProgram);
+        }
+
+        Ok(Self { info, is_spl_token })
+    }
+}

--- a/program/src/validation/uninitialized_account_info.rs
+++ b/program/src/validation/uninitialized_account_info.rs
@@ -1,0 +1,23 @@
+use dropset_interface::{error::DropsetError, state::SYSTEM_PROGRAM_ID, utils::owned_by};
+use pinocchio::account_info::AccountInfo;
+
+/// Represents a completely uninitialized account.
+#[derive(Clone)]
+pub struct UninitializedAccountInfo<'a> {
+    pub info: &'a AccountInfo,
+}
+
+impl<'a> UninitializedAccountInfo<'a> {
+    #[inline(always)]
+    pub fn new(info: &'a AccountInfo) -> Result<UninitializedAccountInfo<'a>, DropsetError> {
+        if !info.data_is_empty() {
+            return Err(DropsetError::AlreadyInitializedAccount);
+        }
+
+        if !owned_by(info, &SYSTEM_PROGRAM_ID) {
+            return Err(DropsetError::NotOwnedBySystemProgram);
+        }
+
+        Ok(Self { info })
+    }
+}


### PR DESCRIPTION
# Description

- [x] Adds the register market instruction
- [x] Adds the register market context (grouping AccountInfos into named/structured fields)
- [x] Adds the register market account validation, i.e., validating that the accounts are properly prepared/valid for the register instruction

Accidentally merged into the wrong branch again, I don't know why it keeps not updating the base branch when the base merges to main