### PR TITLE
[ENG-32]: Fix market seeds + num accounts passed; add `debug` feature with logs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,7 +105,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -135,7 +144,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -228,7 +237,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -267,11 +276,13 @@ dependencies = [
  "dropset-interface",
  "pinocchio",
  "pinocchio-associated-token-account",
+ "pinocchio-log",
  "pinocchio-pubkey",
  "pinocchio-system",
  "pinocchio-token",
  "pinocchio-token-2022",
  "pinocchio-token-interface",
+ "solana-msg",
  "solana-pubkey",
  "static_assertions",
 ]
@@ -506,7 +517,7 @@ dependencies = [
  "quote",
  "strum",
  "strum_macros",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -630,7 +641,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -691,6 +702,26 @@ checksum = "d67472f0743a13e87da3acf259e23dc711066236a1118d885ea20a264bf7954b"
 dependencies = [
  "pinocchio",
  "pinocchio-pubkey",
+]
+
+[[package]]
+name = "pinocchio-log"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd11022408f312e6179ece321c1f7dc0d1b2aa7765fddd39b2a7378d65a899e8"
+dependencies = [
+ "pinocchio-log-macro",
+]
+
+[[package]]
+name = "pinocchio-log-macro"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69fb52edb3c5736b044cc462b0957b9767d0f574d138f4e2761438c498a4b467"
+dependencies = [
+ "quote",
+ "regex",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -838,6 +869,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,7 +994,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1623,7 +1683,7 @@ dependencies = [
  "bs58",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1906,7 +1966,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1914,6 +1974,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -1943,7 +2014,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -2057,7 +2128,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.107",
 ]
 
 [[package]]

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -13,17 +13,17 @@ solana-cpi = { workspace = true, optional = true}
 solana-instruction = { workspace = true, optional = true }
 solana-sdk = { workspace = true, optional = true}
 static_assertions.workspace = true
+strum_macros = { workspace = true, optional = true }
 
 [dev-dependencies]
 strum.workspace = true
-strum_macros.workspace = true
 
 [lints]
 workspace = true
 
 [features]
-default = ["solana-sdk-invoke"]
-client = ["std", "dep:solana-instruction", "dep:solana-cpi", "dep:solana-sdk"]
+default = []
+client = ["std", "dep:strum_macros", "dep:solana-instruction", "dep:solana-cpi", "dep:solana-sdk"]
 std = []
 pinocchio-invoke = []
 solana-sdk-invoke = ["dep:solana-instruction", "dep:solana-cpi", "dep:solana-sdk"]

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -1,6 +1,7 @@
 use pinocchio::program_error::ProgramError;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[cfg_attr(feature = "client", derive(strum_macros::FromRepr))]
 #[repr(u8)]
 pub enum DropsetError {
     InvalidInstructionTag,
@@ -13,7 +14,7 @@ pub enum DropsetError {
     UnalignedData,
     UnallocatedAccountData,
     UserAlreadyExists,
-    NotEnoughAccountKeys,
+    IncorrectNumberOfAccountInfos,
     InvalidTokenProgram,
     AlreadyInitializedAccount,
     AccountNotInitialized,
@@ -51,7 +52,9 @@ impl From<DropsetError> for &'static str {
             DropsetError::UnalignedData => "Account data is unaligned",
             DropsetError::UnallocatedAccountData => "Account data hasn't been properly allocated",
             DropsetError::UserAlreadyExists => "User already has an existing seat",
-            DropsetError::NotEnoughAccountKeys => "Not enough account keys were provided",
+            DropsetError::IncorrectNumberOfAccountInfos => {
+                "Number of account infos passed is incorrect"
+            }
             DropsetError::InvalidTokenProgram => "Invalid token program ID",
             DropsetError::AlreadyInitializedAccount => "Account has already been initialized",
             DropsetError::AccountNotInitialized => "Account hasn't been initialized",

--- a/interface/src/instructions.rs
+++ b/interface/src/instructions.rs
@@ -4,16 +4,19 @@ use instruction_macros::ProgramInstruction;
 #[derive(Clone, Copy, Debug, PartialEq, ProgramInstruction)]
 #[program_instruction(error = pinocchio::program_error::ProgramError::InvalidInstructionData)]
 #[cfg_attr(test, derive(strum_macros::FromRepr, strum_macros::EnumIter))]
+#[cfg_attr(feature = "client", derive(strum_macros::Display))]
 #[rustfmt::skip]
 pub enum DropsetInstruction {
-    #[account(0, signer,   name = "user",             desc = "The user closing their seat.")]
-    #[account(1, writable, name = "market_account",   desc = "The market account PDA.")]
-    #[account(2, writable, name = "base_user_ata",    desc = "The user's associated base mint token account.")]
-    #[account(3, writable, name = "quote_user_ata",   desc = "The user's associated quote mint token account.")]
-    #[account(4, writable, name = "base_market_ata",  desc = "The market's associated base mint token account.")]
-    #[account(5, writable, name = "quote_market_ata", desc = "The market's associated quote mint token account.")]
-    #[account(6,           name = "base_mint",        desc = "The base token mint account.")]
-    #[account(7,           name = "quote_mint",       desc = "The quote token mint account.")]
+    #[account(0, signer,   name = "user",                desc = "The user closing their seat.")]
+    #[account(1, writable, name = "market_account",      desc = "The market account PDA.")]
+    #[account(2, writable, name = "base_user_ata",       desc = "The user's associated base mint token account.")]
+    #[account(3, writable, name = "quote_user_ata",      desc = "The user's associated quote mint token account.")]
+    #[account(4, writable, name = "base_market_ata",     desc = "The market's associated base mint token account.")]
+    #[account(5, writable, name = "quote_market_ata",    desc = "The market's associated quote mint token account.")]
+    #[account(6,           name = "base_mint",           desc = "The base token mint account.")]
+    #[account(7,           name = "quote_mint",          desc = "The quote token mint account.")]
+    #[account(8,           name = "base_token_program",  desc = "The base mint's token program.")]
+    #[account(9,           name = "quote_token_program", desc = "The quote mint's token program.")]
     #[args(sector_index_hint: u32, "A hint indicating which sector the user's seat resides in.")]
     CloseSeat,
 
@@ -22,6 +25,7 @@ pub enum DropsetInstruction {
     #[account(2, writable, name = "user_ata",       desc = "The user's associated token account.")]
     #[account(3, writable, name = "market_ata",     desc = "The market's associated token account.")]
     #[account(4,           name = "mint",           desc = "The token mint account.")]
+    #[account(5,           name = "token_program",  desc = "The mint's token program.")]
     #[args(amount: u64, "The amount to deposit.")]
     #[args(sector_index_hint: u32, "A hint indicating which sector the user's seat resides in (pass `NIL` when registering a new seat).")]
     Deposit,
@@ -34,7 +38,8 @@ pub enum DropsetInstruction {
     #[account(5,           name = "quote_mint",          desc = "The quote mint account.")]
     #[account(6,           name = "base_token_program",  desc = "The base mint's token program.")]
     #[account(7,           name = "quote_token_program", desc = "The quote mint's token program.")]
-    #[account(8,           name = "system_program",      desc = "The system program.")]
+    #[account(8,           name = "ata_program",         desc = "The associated token account program.")]
+    #[account(9,           name = "system_program",      desc = "The system program.")]
     #[args(num_sectors: u16, "The number of sectors to preallocate for the market.")]
     RegisterMarket,
 
@@ -43,11 +48,14 @@ pub enum DropsetInstruction {
     #[account(2, writable, name = "user_ata",       desc = "The user's associated token account.")]
     #[account(3, writable, name = "market_ata",     desc = "The market's associated token account.")]
     #[account(4,           name = "mint",           desc = "The token mint account.")]
+    #[account(5,           name = "token_program",  desc = "The mint's token program.")]
     #[args(amount: u64, "The amount to withdraw.")]
     #[args(sector_index_hint: u32, "A hint indicating which sector the user's seat resides in.")]
     Withdraw,
 
+    #[account(0, signer, name = "event_authority", desc = "Flush events")]
     FlushEvents,
+
     Batch,
 }
 

--- a/interface/src/state/market_header.rs
+++ b/interface/src/state/market_header.rs
@@ -20,7 +20,7 @@ pub struct MarketHeader {
     /// The u32 total number of fully initialized seats as LE bytes.
     num_seats: LeU32,
     /// The u32 total number of sectors in the free stack as LE bytes.
-    num_free_sectors: LeSectorIndex,
+    num_free_sectors: LeU32,
     /// The u32 sector index of the first node in the stack of free nodes as LE bytes.
     free_stack_top: LeSectorIndex,
     /// The u32 sector index of the first node in the doubly linked list of seat nodes as LE bytes.
@@ -158,5 +158,15 @@ impl MarketHeader {
     #[inline(always)]
     pub fn set_seat_dll_tail(&mut self, index: SectorIndex) {
         self.seat_dll_tail = index.to_le_bytes();
+    }
+
+    #[inline(always)]
+    pub fn nonce(&self) -> u64 {
+        u64::from_le_bytes(self.nonce)
+    }
+
+    #[inline(always)]
+    pub fn increment_nonce(&mut self) {
+        self.nonce = (self.nonce().saturating_add(1)).to_le_bytes();
     }
 }

--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -8,14 +8,16 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 bytemuck.workspace = true
-dropset-interface = { path = "../interface", features = ["pinocchio-invoke"], default-features = false }
+dropset-interface = { path = "../interface", features = [], default-features = false }
 pinocchio.workspace = true
 pinocchio-associated-token-account.workspace = true
+pinocchio-log = { workspace = true, optional = true }
 pinocchio-pubkey.workspace = true
 pinocchio-system.workspace = true
 pinocchio-token.workspace = true
 pinocchio-token-interface.workspace = true
 pinocchio-token-2022.workspace = true
+solana-msg = { workspace = true, optional = true }
 static_assertions.workspace = true
 
 [dev-dependencies]
@@ -28,3 +30,4 @@ workspace = true
 default = []
 std = []
 no-entrypoint = []
+debug = ["dep:pinocchio-log"]

--- a/program/src/context/close_seat_context.rs
+++ b/program/src/context/close_seat_context.rs
@@ -16,6 +16,8 @@ pub struct CloseSeatContext<'a> {
     pub quote_market_ata: TokenAccountInfo<'a>,
     pub base_mint: MintInfo<'a>,
     pub quote_mint: MintInfo<'a>,
+    pub _base_token_program: &'a AccountInfo,
+    pub _quote_token_program: &'a AccountInfo,
 }
 
 impl<'a> CloseSeatContext<'a> {
@@ -30,8 +32,10 @@ impl<'a> CloseSeatContext<'a> {
             quote_market_ata,
             base_mint,
             quote_mint,
+            _base_token_program,
+            _quote_token_program,
         ] = accounts else {
-            return Err(DropsetError::NotEnoughAccountKeys.into());
+            return Err(DropsetError::IncorrectNumberOfAccountInfos.into());
         };
 
         // Safety: Scoped borrow of market account data.
@@ -68,6 +72,8 @@ impl<'a> CloseSeatContext<'a> {
             quote_market_ata,
             base_mint,
             quote_mint,
+            _base_token_program,
+            _quote_token_program,
         })
     }
 }

--- a/program/src/context/deposit_withdraw_context.rs
+++ b/program/src/context/deposit_withdraw_context.rs
@@ -13,6 +13,7 @@ pub struct DepositWithdrawContext<'a> {
     pub user_ata: TokenAccountInfo<'a>,
     pub market_ata: TokenAccountInfo<'a>,
     pub mint: MintInfo<'a>,
+    pub _token_program: &'a AccountInfo,
 }
 
 impl<'a> DepositWithdrawContext<'a> {
@@ -36,8 +37,10 @@ impl<'a> DepositWithdrawContext<'a> {
             user_ata,
             market_ata,
             mint,
+            _token_program,
+
         ] = accounts else {
-            return Err(DropsetError::NotEnoughAccountKeys.into());
+            return Err(DropsetError::IncorrectNumberOfAccountInfos.into());
         };
 
         // Safety: Scoped borrow of market account data.
@@ -62,6 +65,7 @@ impl<'a> DepositWithdrawContext<'a> {
             user_ata,
             market_ata,
             mint,
+            _token_program,
         })
     }
 }

--- a/program/src/context/register_market_context.rs
+++ b/program/src/context/register_market_context.rs
@@ -13,6 +13,7 @@ pub struct RegisterMarketContext<'a> {
     pub quote_mint: &'a AccountInfo,
     pub base_token_program: &'a AccountInfo,
     pub quote_token_program: &'a AccountInfo,
+    pub _ata_program: &'a AccountInfo,
     pub system_program: &'a AccountInfo,
 }
 
@@ -28,9 +29,10 @@ impl<'a> RegisterMarketContext<'a> {
             quote_mint,
             base_token_program,
             quote_token_program,
+            _ata_program,
             system_program,
         ] = accounts else {
-            return Err(DropsetError::NotEnoughAccountKeys);
+            return Err(DropsetError::IncorrectNumberOfAccountInfos);
         };
 
         // Since the market PDA and both of its associated token accounts are created atomically
@@ -40,6 +42,7 @@ impl<'a> RegisterMarketContext<'a> {
         // Thus there is no need to check ownership, address derivations, or account data here, only
         // that the `market_account` is uninitialized.
         // The token programs are also validated in the ATA `Create` instruction.
+        // The associated token program is hard-coded as an address and never even used.
         let market_account = UninitializedAccountInfo::new(market_account)?;
 
         Ok(Self {
@@ -51,6 +54,7 @@ impl<'a> RegisterMarketContext<'a> {
             quote_mint,
             base_token_program,
             quote_token_program,
+            _ata_program,
             system_program,
         })
     }

--- a/program/src/debug.rs
+++ b/program/src/debug.rs
@@ -1,0 +1,8 @@
+/// Debug macro that wraps pinocchio_log::log!
+#[macro_export]
+macro_rules! debug {
+    ($($arg:tt)*) => {
+        #[cfg(feature = "debug")]
+        pinocchio_log::log!($($arg)*)
+    };
+}

--- a/program/src/instructions/close_seat.rs
+++ b/program/src/instructions/close_seat.rs
@@ -1,7 +1,6 @@
 use dropset_interface::{
     instructions::CloseSeatInstructionData, state::node::Node, utils::is_owned_by_spl_token,
 };
-use dropset_interface::{state::node::Node, utils::is_owned_by_spl_token};
 use pinocchio::{account_info::AccountInfo, ProgramResult};
 
 use crate::{

--- a/program/src/instructions/deposit.rs
+++ b/program/src/instructions/deposit.rs
@@ -1,6 +1,6 @@
 use dropset_interface::{
     instructions::DepositInstructionData,
-    state::{market_seat::MarketSeat, node::Node, sector::SectorIndex},
+    state::{market_seat::MarketSeat, node::Node, sector::NIL},
 };
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError, ProgramResult};
 
@@ -31,19 +31,19 @@ pub unsafe fn process_deposit(accounts: &[AccountInfo], instruction_data: &[u8])
         amount,
         sector_index_hint,
     } = DepositInstructionData::unpack(instruction_data)?;
-    let hint = SectorIndex(sector_index_hint);
 
     let mut ctx = unsafe { DepositWithdrawContext::load(accounts) }?;
+
     let amount_deposited = unsafe { deposit_non_zero_to_market(&ctx, amount) }?;
 
     // 1) Update an existing seat.
-    if !hint.is_nil() {
-        let index = hint;
+    if sector_index_hint != NIL {
         // Safety: Scoped mutable borrow of the market account to mutate the user's seat.
         let market = unsafe { ctx.market_account.load_unchecked_mut() };
-        Node::check_in_bounds(market.sectors, index)?;
+
+        Node::check_in_bounds(market.sectors, sector_index_hint)?;
         // Safety: The index hint was just verified as in-bounds.
-        let seat = unsafe { find_mut_seat_with_hint(market, index, ctx.user.key()) }?;
+        let seat = unsafe { find_mut_seat_with_hint(market, sector_index_hint, ctx.user.key()) }?;
 
         if ctx.mint.is_base_mint {
             seat.set_base_available(

--- a/program/src/instructions/register_market.rs
+++ b/program/src/instructions/register_market.rs
@@ -11,7 +11,7 @@ use pinocchio::{
 };
 
 use crate::{
-    context::register_market_context::RegisterMarketContext, market_signer,
+    context::register_market_context::RegisterMarketContext, market_seeds, market_signer,
     shared::market_operations::initialize_market_account_data,
 };
 
@@ -27,9 +27,11 @@ pub unsafe fn process_register_market(
 
     // It's not necessary to check the returned PDA here because `CreateAccount` will fail if the
     // market account info's pubkey doesn't match.
-    let (_pda, market_bump) =
-        try_find_program_address(&[ctx.base_mint.key(), ctx.quote_mint.key()], &crate::ID)
-            .ok_or(DropsetError::AddressDerivationFailed)?;
+    let (_pda, market_bump) = try_find_program_address(
+        market_seeds!(ctx.base_mint.key(), ctx.quote_mint.key()),
+        &crate::ID,
+    )
+    .ok_or(DropsetError::AddressDerivationFailed)?;
 
     // Calculate the lamports required to create the market account.
     let account_space = MarketHeader::LEN + SECTOR_SIZE * (num_sectors as usize);

--- a/program/src/instructions/withdraw.rs
+++ b/program/src/instructions/withdraw.rs
@@ -1,7 +1,5 @@
 use dropset_interface::{
-    error::DropsetError,
-    instructions::WithdrawInstructionData,
-    state::{node::Node, sector::SectorIndex},
+    error::DropsetError, instructions::WithdrawInstructionData, state::node::Node,
 };
 use pinocchio::{account_info::AccountInfo, ProgramResult};
 
@@ -23,7 +21,6 @@ pub unsafe fn process_withdraw(accounts: &[AccountInfo], instruction_data: &[u8]
         amount,
         sector_index_hint,
     } = WithdrawInstructionData::unpack(instruction_data)?;
-    let hint = SectorIndex(sector_index_hint);
 
     // Safety: Scoped immutable borrow of market, user token, and market token accounts to validate.
     let mut ctx = unsafe { DepositWithdrawContext::load(accounts) }?;
@@ -33,9 +30,9 @@ pub unsafe fn process_withdraw(accounts: &[AccountInfo], instruction_data: &[u8]
     let market = unsafe { ctx.market_account.load_unchecked_mut() };
 
     // Find the seat with the index hint or fail and return early.
-    Node::check_in_bounds(market.sectors, hint)?;
+    Node::check_in_bounds(market.sectors, sector_index_hint)?;
     // Safety: The hint was just verified as in-bounds.
-    let seat = unsafe { find_mut_seat_with_hint(market, hint, ctx.user.key()) }?;
+    let seat = unsafe { find_mut_seat_with_hint(market, sector_index_hint, ctx.user.key()) }?;
 
     // Update the market seat available/deposited, checking for underflow, as that means the user
     // tried to withdraw more than they have available.

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -4,6 +4,7 @@
 extern crate std;
 
 mod context;
+mod debug;
 mod instructions;
 mod shared;
 mod validation;

--- a/program/src/shared/seeds.rs
+++ b/program/src/shared/seeds.rs
@@ -2,6 +2,17 @@ pub mod market {
     pub const MARKET_SEED_STR: &[u8] = b"market";
 }
 
+#[macro_export]
+macro_rules! market_seeds {
+    ($base:expr, $quote:expr) => {
+        &[
+            $base.as_ref(),
+            $quote.as_ref(),
+            $crate::shared::seeds::market::MARKET_SEED_STR,
+        ]
+    };
+}
+
 /// # Example
 ///
 /// ```
@@ -13,10 +24,10 @@ pub mod market {
 /// ```
 #[macro_export]
 macro_rules! market_signer {
-    ( $base_mint:expr, $quote_mint:expr, $bump:expr ) => {
+    ( $base:expr, $quote:expr, $bump:expr ) => {
         pinocchio::instruction::Signer::from(&pinocchio::seeds!(
-            $base_mint.as_ref(),
-            $quote_mint.as_ref(),
+            $base.as_ref(),
+            $quote.as_ref(),
             $crate::shared::seeds::market::MARKET_SEED_STR,
             &[$bump]
         ))


### PR DESCRIPTION
# Description

Fairly self-explanatory:

- [x] Fixes the market seeds
- [x] Fixes the number of accounts passed to deposit and withdraw
- [x] Adds the `debug` feature to facilitate logging with `pinocchio::log` but not pulling in the dependency if disabled