### PR TITLE
[ENG-33]: Make `SectorIndex` a type alias instead of a newtype

### DIFF
--- a/interface/src/instructions/close_seat.rs
+++ b/interface/src/instructions/close_seat.rs
@@ -98,7 +98,7 @@ impl CloseSeat<'_> {
         let mut data = [UNINIT_BYTE; 5];
 
         data[0].write(InstructionTag::CloseSeat as u8);
-        write_bytes(&mut data[1..5], &self.sector_index_hint.0.to_le_bytes());
+        write_bytes(&mut data[1..5], &self.sector_index_hint.to_le_bytes());
 
         // Safety: All 5 bytes were written to.
         unsafe { *(data.as_ptr() as *const _) }

--- a/interface/src/instructions/deposit.rs
+++ b/interface/src/instructions/deposit.rs
@@ -89,7 +89,7 @@ impl Deposit<'_> {
 
         data[0].write(InstructionTag::Deposit as u8);
         write_bytes(&mut data[1..9], &self.amount.to_le_bytes());
-        write_bytes(&mut data[9..13], &self.sector_index_hint.0.to_le_bytes());
+        write_bytes(&mut data[9..13], &self.sector_index_hint.to_le_bytes());
 
         // Safety: All 13 bytes were written to.
         unsafe { *(data.as_ptr() as *const _) }

--- a/interface/src/instructions/withdraw.rs
+++ b/interface/src/instructions/withdraw.rs
@@ -87,7 +87,7 @@ impl Withdraw<'_> {
 
         data[0].write(InstructionTag::Withdraw as u8);
         write_bytes(&mut data[1..9], &self.amount.to_le_bytes());
-        write_bytes(&mut data[9..13], &self.sector_index_hint.0.to_le_bytes());
+        write_bytes(&mut data[9..13], &self.sector_index_hint.to_le_bytes());
 
         // Safety: All 13 bytes were written to.
         unsafe { *(data.as_ptr() as *const _) }

--- a/interface/src/state/linked_list.rs
+++ b/interface/src/state/linked_list.rs
@@ -43,7 +43,7 @@ impl<'a> LinkedList<'a> {
         new_node.set_prev(NIL);
         new_node.set_next(head_index);
 
-        if head_index.is_nil() {
+        if head_index == NIL {
             // If the head is NIL, the new node is the only node and is thus also the tail.
             self.header.set_seat_dll_tail(new_index);
         } else {
@@ -75,7 +75,7 @@ impl<'a> LinkedList<'a> {
         new_node.set_prev(tail_index);
         new_node.set_next(NIL);
 
-        if tail_index.is_nil() {
+        if tail_index == NIL {
             // If the tail is NIL, the new node is the only node and is thus also the head.
             self.header.set_seat_dll_head(new_index);
         } else {
@@ -118,7 +118,7 @@ impl<'a> LinkedList<'a> {
         new_node.set_next(next_index);
         new_node.set_payload(payload);
 
-        if prev_index.is_nil() {
+        if prev_index == NIL {
             // If `prev_index` is NIL, that means `next_index` was the head prior to this insertion,
             // so the `head` needs to be updated to the new node's index.
             self.header.set_seat_dll_head(new_index);
@@ -186,7 +186,7 @@ impl<'a> Iterator for LinkedListIter<'a> {
 
     /// Returns the next node if it's non-NIL, otherwise, returns `None`.
     fn next(&mut self) -> Option<(SectorIndex, &'a Node)> {
-        if self.curr.is_nil() {
+        if self.curr == NIL {
             return None;
         }
 

--- a/interface/src/state/market_header.rs
+++ b/interface/src/state/market_header.rs
@@ -75,9 +75,9 @@ impl MarketHeader {
             discriminant: MARKET_ACCOUNT_DISCRIMINANT.to_le_bytes(),
             num_seats: [0; U32_SIZE],
             num_free_sectors: [0; U32_SIZE],
-            free_stack_top: NIL.into(),
-            seat_dll_head: NIL.into(),
-            seat_dll_tail: NIL.into(),
+            free_stack_top: NIL.to_le_bytes(),
+            seat_dll_head: NIL.to_le_bytes(),
+            seat_dll_tail: NIL.to_le_bytes(),
             base_mint: *base_mint,
             quote_mint: *quote_mint,
             market_bump,
@@ -132,31 +132,31 @@ impl MarketHeader {
 
     #[inline(always)]
     pub fn free_stack_top(&self) -> SectorIndex {
-        self.free_stack_top.into()
+        u32::from_le_bytes(self.free_stack_top)
     }
 
     #[inline(always)]
     pub fn set_free_stack_top(&mut self, index: SectorIndex) {
-        self.free_stack_top = index.into();
+        self.free_stack_top = index.to_le_bytes();
     }
 
     #[inline(always)]
     pub fn seat_dll_head(&self) -> SectorIndex {
-        self.seat_dll_head.into()
+        u32::from_le_bytes(self.seat_dll_head)
     }
 
     #[inline(always)]
     pub fn set_seat_dll_head(&mut self, index: SectorIndex) {
-        self.seat_dll_head = index.into();
+        self.seat_dll_head = index.to_le_bytes();
     }
 
     #[inline(always)]
     pub fn seat_dll_tail(&self) -> SectorIndex {
-        self.seat_dll_tail.into()
+        u32::from_le_bytes(self.seat_dll_tail)
     }
 
     #[inline(always)]
     pub fn set_seat_dll_tail(&mut self, index: SectorIndex) {
-        self.seat_dll_tail = index.into();
+        self.seat_dll_tail = index.to_le_bytes();
     }
 }

--- a/interface/src/state/node.rs
+++ b/interface/src/state/node.rs
@@ -55,22 +55,22 @@ const_assert_eq!(align_of::<Node>(), 1);
 impl Node {
     #[inline(always)]
     pub fn prev(&self) -> SectorIndex {
-        self.prev.into()
+        u32::from_le_bytes(self.prev)
     }
 
     #[inline(always)]
     pub fn set_prev(&mut self, index: SectorIndex) {
-        self.prev = index.into();
+        self.prev = index.to_le_bytes();
     }
 
     #[inline(always)]
     pub fn next(&self) -> SectorIndex {
-        self.next.into()
+        u32::from_le_bytes(self.next)
     }
 
     #[inline(always)]
     pub fn set_next(&mut self, index: SectorIndex) {
-        self.next = index.into();
+        self.next = index.to_le_bytes();
     }
 
     #[inline(always)]
@@ -125,7 +125,7 @@ impl Node {
     #[inline(always)]
     pub fn check_in_bounds(sectors: &[u8], index: SectorIndex) -> DropsetResult {
         let max_num_sectors = (sectors.len() / Self::LEN) as u32;
-        if index.0 >= max_num_sectors {
+        if index >= max_num_sectors {
             return Err(DropsetError::IndexOutOfBounds);
         };
 
@@ -139,7 +139,7 @@ impl Node {
     /// Caller guarantees `index * Self::LEN` is within the bounds of `sectors` bytes.
     #[inline(always)]
     pub unsafe fn from_sector_index(sectors: &[u8], index: SectorIndex) -> &Self {
-        let byte_offset = index.0 as usize * Self::LEN;
+        let byte_offset = index as usize * Self::LEN;
         unsafe { &*(sectors.as_ptr().add(byte_offset) as *const Node) }
     }
 
@@ -150,7 +150,7 @@ impl Node {
     /// Caller guarantees `index * Self::LEN` is within the bounds of `sectors` bytes.
     #[inline(always)]
     pub unsafe fn from_sector_index_mut(sectors: &mut [u8], index: SectorIndex) -> &mut Self {
-        let byte_offset = index.0 as usize * Self::LEN;
+        let byte_offset = index as usize * Self::LEN;
         unsafe { &mut *(sectors.as_mut_ptr().add(byte_offset) as *mut Node) }
     }
 }

--- a/interface/src/state/sector.rs
+++ b/interface/src/state/sector.rs
@@ -2,39 +2,16 @@ use crate::state::U32_SIZE;
 
 pub const SECTOR_SIZE: usize = 72;
 
-/// A sentinel sector index.
+/// A sentinel value that marks 1-past the last valid sector index.
 ///
-/// u32::MAX is safe as a sentinel value because the max sector index in an account is essentially
-/// MAX_SOLANA_ACCOUNT_SIZE / SECTOR_SIZE. Even at a sector size of 1 byte, the max account size
-/// of 10 megabytes would mean the max sector index (~10.5 million) is still far less than u32::MAX.
-pub const NIL: SectorIndex = SectorIndex(u32::MAX);
+/// This value will never appear naturally. Even at a sector size of 1 byte, Solana's max account
+/// size of 10 MB would put the max sector index at ~10.5 mil — far less than u32::MAX.
+pub const NIL: SectorIndex = u32::MAX;
 
-// An alias type for readability.
+// An alias type for a sector index stored as little-endian bytes.
 pub type LeSectorIndex = [u8; U32_SIZE];
 
-#[repr(transparent)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 /// A stride-based index into an array of sectors.
 ///
 /// Index `i` maps to byte offset `i × SECTOR_SIZE` for a raw `sectors: &[u8]` slice.
-pub struct SectorIndex(pub u32);
-
-impl SectorIndex {
-    #[inline(always)]
-    pub fn is_nil(&self) -> bool {
-        self.0 == NIL.0
-    }
-}
-
-impl From<[u8; U32_SIZE]> for SectorIndex {
-    fn from(value: [u8; U32_SIZE]) -> Self {
-        SectorIndex(u32::from_le_bytes(value))
-    }
-}
-
-impl From<SectorIndex> for [u8; U32_SIZE] {
-    #[inline(always)]
-    fn from(value: SectorIndex) -> Self {
-        value.0.to_le_bytes()
-    }
-}
+pub type SectorIndex = u32;

--- a/program/src/instructions/close_seat.rs
+++ b/program/src/instructions/close_seat.rs
@@ -1,8 +1,4 @@
-use dropset_interface::{
-    pack::unpack_u32,
-    state::{node::Node, sector::SectorIndex},
-    utils::is_owned_by_spl_token,
-};
+use dropset_interface::{pack::unpack_u32, state::node::Node, utils::is_owned_by_spl_token};
 use pinocchio::{account_info::AccountInfo, ProgramResult};
 
 use crate::{
@@ -16,7 +12,7 @@ use crate::{
 ///
 /// Caller guarantees the safety contract detailed in [`dropset_interface::instructions::close_seat::CloseSeat`]
 pub fn process_close_seat(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
-    let hint = SectorIndex(unpack_u32(instruction_data)?);
+    let hint = unpack_u32(instruction_data)?;
     let mut ctx = unsafe { CloseSeatContext::load(accounts) }?;
 
     // Get the market bump and the base and quote amounts available for the user.

--- a/program/src/shared/market_operations.rs
+++ b/program/src/shared/market_operations.rs
@@ -20,7 +20,7 @@ pub fn insert_market_seat(
     let seat_bytes = seat.as_array();
 
     // Return an error early if the user already exists in the seat list at the previous index.
-    if !prev_index.is_nil() {
+    if prev_index != NIL {
         // Safety: `prev_index` is non-NIL and was returned by an iterator, so it must be in-bounds.
         let prev_node = unsafe { Node::from_sector_index(list.sectors, prev_index) };
         let prev_seat = prev_node.load_payload::<MarketSeat>();


### PR DESCRIPTION
# Description

The newtype ends up being more cumbersome than helpful and slightly unreadable in some cases (I'm not a fan of the `.0` syntax, as it is slightly obfuscating).

- [x] Refactor the `SectorIndex` new type into a simple type alias
