### PR TITLE
[ENG-47] Fix bug with stack `top` not being set when a free node is removed/acquired

### DIFF
--- a/interface/src/state/free_stack.rs
+++ b/interface/src/state/free_stack.rs
@@ -133,12 +133,13 @@ impl<'a> Stack<'a> {
         // Safety: The free index was just checked as in-bounds.
         let node_being_freed = unsafe { Node::from_sector_index_mut(self.sectors, free_index) };
 
+        // Copy the current top's `next` as that will become the new `top`.
+        let new_top = node_being_freed.next();
+
         // Zero out the rest of the node by setting `next` to 0. The payload and `prev` were zeroed
         // out when adding to the free list.
         node_being_freed.set_next(0);
 
-        // Set the new `top` to the current top's `next`.
-        let new_top = node_being_freed.next();
         self.set_top(new_top);
         self.header.decrement_num_free_sectors();
 

--- a/interface/src/state/linked_list.rs
+++ b/interface/src/state/linked_list.rs
@@ -29,6 +29,7 @@ impl<'a> LinkedList<'a> {
     /// Helper method to pop a node from the free stack.
     ///
     /// A returned `Ok(index)` is always in-bounds and non-NIL.
+    #[inline(always)]
     fn acquire_free_node(&mut self) -> Result<SectorIndex, DropsetError> {
         let mut free_stack = Stack::new_from_parts(self.header, self.sectors);
         free_stack.remove_free_node()


### PR DESCRIPTION
# Description

Fixes a bug that was introduced when refactoring due to having to work around lifetimes.

This was due to the node being zeroed out before it's `next` was copied. It's `next` is used as the new `top`, so using the new zeroed `top` always resulted in an infinite loop of the first node pointing to itself.

