### PR TITLE
[ENG-51]  Add prettified/colored `Display` implementations for transactions, instructions, and instruction errors

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,6 +1,7 @@
 use solana_sdk::pubkey::Pubkey;
 
 pub mod logs;
+pub mod pretty;
 pub mod transaction_parser;
 
 pub use logs::LogColor;

--- a/client/src/pretty/instruction.rs
+++ b/client/src/pretty/instruction.rs
@@ -1,0 +1,172 @@
+use std::fmt::{
+    self,
+    Debug,
+    Display,
+    Formatter,
+};
+
+use colored::{
+    Color,
+    Colorize,
+};
+use dropset_interface::{
+    instructions::DropsetInstruction,
+    state::SYSTEM_PROGRAM_ID,
+};
+use solana_compute_budget_interface::ComputeBudgetInstruction;
+use solana_sdk::pubkey::Pubkey;
+use solana_system_interface::instruction::SystemInstruction;
+use spl_associated_token_account_interface::instruction::AssociatedTokenAccountInstruction;
+use spl_token_2022_interface::instruction::TokenInstruction as Token2022Instruction;
+use spl_token_interface::instruction::TokenInstruction;
+
+use crate::{
+    logs::LogColor,
+    transaction_parser::ParsedInstruction,
+    COMPUTE_BUDGET_ID,
+    SPL_ASSOCIATED_TOKEN_ACCOUNT_ID,
+    SPL_TOKEN_2022_ID,
+    SPL_TOKEN_ID,
+};
+
+pub struct PrettyInstruction<'a> {
+    pub instruction: &'a ParsedInstruction,
+    pub outer: bool,
+}
+
+impl Display for PrettyInstruction<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let instruction = self.instruction;
+        let program_id = &instruction.program_id;
+        let known_program = KnownProgram::from_program_id(program_id);
+
+        let name_highlight_color = match (self.outer, known_program.is_some()) {
+            (true, true) => LogColor::Debug.into(),
+            (false, true) => Color::BrightBlack,
+            (_, false) => LogColor::Warning.into(),
+        };
+
+        let compute_units = self.format_cu();
+
+        let (program_name, instruction_name) = match known_program {
+            Some(known) => (known.to_string(), known.instruction_name(&instruction.data)),
+            None => (program_id.to_string(), "UnknownInstruction".into()),
+        };
+
+        let colored_name = program_name.color(name_highlight_color);
+        let s = format!("{colored_name}::{instruction_name}{compute_units}");
+
+        f.write_str(&s)
+    }
+}
+
+impl PrettyInstruction<'_> {
+    fn format_cu(&self) -> String {
+        self.instruction
+            .compute_info
+            .as_ref()
+            .and_then(|cu| cu.units_consumed)
+            .map(|cu| {
+                let cu_highlight_color = match self.outer {
+                    true => color_from_value(cu),
+                    false => Color::BrightBlack,
+                };
+                let highlighted_cu = format!("{cu}").color(cu_highlight_color);
+                match self.outer {
+                    true => format!(" consumed {} compute units", highlighted_cu)
+                        .color(LogColor::FadedGray)
+                        .to_string(),
+                    false => format!(" — {} cu", highlighted_cu),
+                }
+            })
+            .unwrap_or_default()
+    }
+}
+
+#[derive(strum_macros::Display)]
+#[strum(serialize_all = "snake_case")]
+enum KnownProgram {
+    Dropset,
+    SplToken,
+    SplToken2022,
+    SystemProgram,
+    AssociatedTokenAccount,
+    ComputeBudget,
+}
+
+impl KnownProgram {
+    pub const fn from_program_id(program_id: &Pubkey) -> Option<Self> {
+        match program_id.to_bytes() {
+            dropset::ID => Some(Self::Dropset),
+            SPL_TOKEN_ID => Some(Self::SplToken),
+            SPL_TOKEN_2022_ID => Some(Self::SplToken2022),
+            SYSTEM_PROGRAM_ID => Some(Self::SystemProgram),
+            SPL_ASSOCIATED_TOKEN_ACCOUNT_ID => Some(Self::AssociatedTokenAccount),
+            COMPUTE_BUDGET_ID => Some(Self::ComputeBudget),
+            _ => None,
+        }
+    }
+
+    pub fn instruction_name(&self, instruction_data: &[u8]) -> String {
+        match self {
+            Self::Dropset => {
+                let tag = instruction_data
+                    .first()
+                    .expect("Dropset instruction should have at least one byte");
+                let dropset_tag = DropsetInstruction::try_from(*tag)
+                    .expect("Dropset instruction tag should be valid");
+                enum_name(&dropset_tag)
+            }
+            Self::SplToken => {
+                let token_instruction = TokenInstruction::unpack(instruction_data)
+                    .expect("Should unpack token instruction data");
+                enum_name(&token_instruction)
+            }
+            Self::SplToken2022 => {
+                let token_instruction = Token2022Instruction::unpack(instruction_data)
+                    .expect("Should unpack token 2022 instruction data");
+                enum_name(&token_instruction)
+            }
+            Self::SystemProgram => {
+                let system_instruction =
+                    bincode::deserialize::<SystemInstruction>(instruction_data)
+                        .expect("Should deserialize system instruction data");
+                enum_name(&system_instruction)
+            }
+            Self::AssociatedTokenAccount => {
+                let spl_ata_instruction =
+                    borsh::from_slice::<AssociatedTokenAccountInstruction>(instruction_data)
+                        .expect("Should deserialize spl ata instruction data");
+                enum_name(&spl_ata_instruction)
+            }
+            Self::ComputeBudget => {
+                let compute_budget_instruction =
+                    bincode::deserialize::<ComputeBudgetInstruction>(instruction_data)
+                        .expect("Should deserialize compute budget instruction data");
+                enum_name(&compute_budget_instruction)
+            }
+        }
+    }
+}
+
+// This should only be used with enums. It assumes that `Debug` will print the value like `Ident {`.
+fn enum_name<T: Debug>(value: &T) -> String {
+    let s = format!("{:?}", value);
+    s.split_once([' ', '{'])
+        .map(|(n, _)| n)
+        .unwrap_or(&s)
+        .into()
+}
+
+const MAX_CU_SATURATION: u64 = 50000;
+
+// Increase color saturation as the CU goes from 0 -> MAX_CU_SATURATION.
+fn color_from_value(v: u64) -> Color {
+    let t = (v.min(MAX_CU_SATURATION) as f64 / 50000.0).powf(1.3);
+    let lerp = |a: f64, b: f64| (a + (b - a) * t).round() as u8;
+    Color::TrueColor {
+        r: lerp(150.0, 255.0),
+        g: lerp(120.0, 160.0),
+        b: lerp(100.0, 20.0),
+    }
+}

--- a/client/src/pretty/instruction_error.rs
+++ b/client/src/pretty/instruction_error.rs
@@ -1,0 +1,121 @@
+use std::fmt::Display;
+
+use colored::Colorize;
+use dropset_interface::{
+    error::DropsetError,
+    instructions::DropsetInstruction,
+};
+use solana_client::{
+    client_error::{
+        ClientError,
+        ClientErrorKind,
+    },
+    rpc_request::{
+        RpcError::RpcResponseError,
+        RpcResponseErrorData,
+    },
+    rpc_response::RpcSimulateTransactionResult,
+};
+use solana_instruction::Instruction;
+use solana_instruction_error::InstructionError as SolanaInstructionError;
+use solana_transaction_error::TransactionError;
+
+use crate::{
+    fmt_kv,
+    LogColor,
+};
+
+enum InstructionError {
+    Solana {
+        instruction_tag: u8,
+        error: SolanaInstructionError,
+    },
+    Dropset {
+        dropset_instruction: DropsetInstruction,
+        error: DropsetError,
+    },
+}
+
+pub struct PrettyInstructionError(InstructionError);
+
+impl PrettyInstructionError {
+    pub fn new(error: &ClientError, instructions: &[Instruction]) -> Option<Self> {
+        match error.kind() {
+            ClientErrorKind::RpcError(RpcResponseError {
+                data:
+                    RpcResponseErrorData::SendTransactionPreflightFailure(
+                        RpcSimulateTransactionResult {
+                            err: Some(ui_err), ..
+                        },
+                    ),
+                ..
+            }) => {
+                let transaction_error: TransactionError = ui_err.clone().into();
+                match transaction_error {
+                    TransactionError::InstructionError(instruction_index, instruction_error) => {
+                        let instruction = instructions
+                            .get(instruction_index as usize)
+                            .expect("Instruction index from error should be valid");
+                        let instruction_tag = instruction.data[0];
+
+                        let res = match instruction_error {
+                            SolanaInstructionError::Custom(code) => {
+                                if instruction.program_id.as_ref() == dropset::ID {
+                                    let dropset_error = DropsetError::from_repr(code as u8)
+                                        .expect("Should be valid");
+                                    let dropset_tag = DropsetInstruction::try_from(instruction_tag)
+                                        .expect("Should be valid");
+
+                                    Self(InstructionError::Dropset {
+                                        dropset_instruction: dropset_tag,
+                                        error: dropset_error,
+                                    })
+                                } else {
+                                    Self(InstructionError::Solana {
+                                        instruction_tag,
+                                        error: SolanaInstructionError::Custom(code),
+                                    })
+                                }
+                            }
+                            instruction_error => Self(InstructionError::Solana {
+                                instruction_tag,
+                                error: instruction_error,
+                            }),
+                        };
+
+                        Some(res)
+                    }
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
+}
+
+impl Display for PrettyInstructionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let (error_type, instruction, error) = match &self.0 {
+            InstructionError::Solana {
+                instruction_tag,
+                error,
+            } => (
+                "SolanaInstructionError",
+                instruction_tag.to_string(),
+                error.to_string(),
+            ),
+            InstructionError::Dropset {
+                dropset_instruction,
+                error,
+            } => (
+                "DropsetError",
+                dropset_instruction.to_string(),
+                error.to_string(),
+            ),
+        };
+
+        let message = format!("{instruction}, {error})");
+        let error_message = fmt_kv!(error_type, message, LogColor::Error);
+        writeln!(f, "{error_message}")
+    }
+}

--- a/client/src/pretty/mod.rs
+++ b/client/src/pretty/mod.rs
@@ -1,0 +1,3 @@
+pub mod instruction;
+pub mod instruction_error;
+pub mod transaction;

--- a/client/src/pretty/transaction.rs
+++ b/client/src/pretty/transaction.rs
@@ -1,0 +1,95 @@
+use std::{
+    collections::HashSet,
+    fmt::{
+        self,
+        Display,
+        Formatter,
+    },
+};
+
+use colored::Colorize;
+use solana_sdk::{
+    pubkey::Pubkey,
+    signature::Signature,
+};
+
+use crate::{
+    fmt_kv,
+    logs::LogColor,
+    pretty::instruction::PrettyInstruction,
+    transaction_parser::ParsedTransaction,
+};
+
+pub struct PrettyTransaction<'a> {
+    /// The transaction signature.
+    pub signature: Signature,
+    /// The sender of the transaction.
+    pub sender: Pubkey,
+    /// The amount of spaces preceding each line in the output.
+    pub indent_size: usize,
+    /// The parsed transaction.
+    pub transaction: &'a ParsedTransaction,
+    /// Instruction program ID filter; i.e., only prints instructions with these IDs.
+    pub instruction_filter: &'a HashSet<Pubkey>,
+}
+
+impl Display for PrettyTransaction<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let filtered = self
+            .transaction
+            .instructions
+            .iter()
+            .filter(|instruction| {
+                self.instruction_filter
+                    .contains(&instruction.outer_instruction.program_id)
+            })
+            .collect::<Vec<_>>();
+
+        if !filtered.is_empty() {
+            let signature = fmt_kv!("Signature", self.signature, LogColor::Header);
+            let sender = fmt_kv!("Sender", self.sender, LogColor::Gray);
+
+            writeln!(f, "{signature}")?;
+            writeln!(f, "{sender}")?;
+        }
+
+        let mut i: usize = 0;
+        for outer in filtered {
+            i += 1;
+            let indentation = " ".repeat(self.indent_size);
+            let pretty_outer = PrettyInstruction {
+                instruction: &outer.outer_instruction,
+                outer: true,
+            };
+
+            let idx = format_instruction_index(i);
+            writeln!(f, "{idx}{indentation}{}", pretty_outer)?;
+
+            for inner in outer.inner_instructions.iter() {
+                i += 1;
+
+                let pretty_instruction = PrettyInstruction {
+                    instruction: inner,
+                    outer: false,
+                };
+                let inner_indent = indentation.repeat(
+                    inner
+                        .compute_info
+                        .as_ref()
+                        .map(|cu| cu.stack_height)
+                        .unwrap_or(1),
+                );
+                let text = format!("{inner_indent} {}", pretty_instruction);
+                let colored = text.color(LogColor::FadedGray);
+                let idx = format_instruction_index(i);
+                writeln!(f, "{idx} {colored}")?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn format_instruction_index(idx: usize) -> String {
+    format!("{idx:>2}").color(LogColor::FadedGray).to_string()
+}


### PR DESCRIPTION
# Description

Adds prettified/colored `Display` implementations for:

- [x] The outer and inner instructions inside of a transaction, including its compute usage, invocation index, and more misc debug data typically shown in the Solana explorer
- [x] Generic transaction data
- [x] Instruction errors, with custom formatting for `DropsetError`s that display the stringified error variant name
