### PR TITLE
[ENG-58] Fix docs markdown hyperlink and add `test-fixtures` module-level doc comment

### DIFF
--- a/instruction-macros/crates/test-fixtures/src/client.rs
+++ b/instruction-macros/crates/test-fixtures/src/client.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "client")]
+#[cfg(test)]
 mod test {
     use instruction_macros::ProgramInstruction;
 
@@ -6,7 +7,7 @@ mod test {
     #[derive(ProgramInstruction)]
     #[program_id(crate::ID)]
     #[rustfmt::skip]
-    pub enum DropsetInstructionClient {
+    pub enum ClientDropsetInstruction {
         #[account(0, signer,   name = "user",                desc = "The user closing their seat.")]
         #[account(1, writable, name = "market_account",      desc = "The market account PDA.")]
         #[account(2, writable, name = "base_user_ata",       desc = "The user's associated base mint token account.")]

--- a/instruction-macros/crates/test-fixtures/src/lib.rs
+++ b/instruction-macros/crates/test-fixtures/src/lib.rs
@@ -1,4 +1,9 @@
-#![doc(hidden)]
+//! Test fixtures for verifying macro expansion across feature namespaces.
+//!
+//! This crate provides isolated environments for testing generated instruction
+//! code under different compilation features (`client`, `pinocchio`, and
+//! `solana-program`).
+
 #![allow(dead_code)]
 #![allow(unused_imports)]
 

--- a/instruction-macros/crates/test-fixtures/src/pinocchio.rs
+++ b/instruction-macros/crates/test-fixtures/src/pinocchio.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "pinocchio")]
+#[cfg(test)]
 pub mod test {
     use instruction_macros::ProgramInstruction;
 
@@ -19,7 +20,7 @@ pub mod test {
     // #[program_id(crate::ID)]
     #[program_id(crate::pinocchio::test::PROGRAM_ID)]
     #[rustfmt::skip]
-    pub enum DropsetInstructionPinocchio {
+    pub enum PinocchioDropsetInstruction {
         #[account(0, signer,   name = "user",                desc = "The user closing their seat.")]
         #[account(1, writable, name = "market_account",      desc = "The market account PDA.")]
         #[account(2, writable, name = "base_user_ata",       desc = "The user's associated base mint token account.")]

--- a/instruction-macros/crates/test-fixtures/src/solana_program.rs
+++ b/instruction-macros/crates/test-fixtures/src/solana_program.rs
@@ -1,4 +1,5 @@
 #[cfg(feature = "solana-program")]
+#[cfg(test)]
 pub mod test {
     use instruction_macros::ProgramInstruction;
 
@@ -6,7 +7,7 @@ pub mod test {
     #[derive(ProgramInstruction)]
     #[program_id(crate::ID)]
     #[rustfmt::skip]
-    pub enum DropsetInstructionSolanaProgram {
+    pub enum SolanaProgramDropsetInstruction {
         #[account(0, signer,   name = "user",                desc = "The user closing their seat.")]
         #[account(1, writable, name = "market_account",      desc = "The market account PDA.")]
         #[account(2, writable, name = "base_user_ata",       desc = "The user's associated base mint token account.")]

--- a/interface/src/state/transmutable.rs
+++ b/interface/src/state/transmutable.rs
@@ -14,7 +14,7 @@
 //! - Added validate_bit_patterns requirement
 //! - Made load/load_mut safe for callers
 //!
-//! Original: https://github.com/solana-program/token/blob/75116550519a9ee3fdfa6c819aca91e383fffa39/p-interface/src/state/mod.rs
+//! Original: <https://github.com/solana-program/token/blob/75116550519a9ee3fdfa6c819aca91e383fffa39/p-interface/src/state/mod.rs>
 
 use crate::error::{
     DropsetError,


### PR DESCRIPTION
# Description

- [x] Fix docs markdown hyperlink
- [x] Add `test-fixtures` module-level doc comment