### PR TITLE
[ENG-89] Add `dropset_program` to each instruction's accounts list; `inline(never)` instruction handlers

### DIFF
--- a/client/examples/deposit_and_withdraw.rs
+++ b/client/examples/deposit_and_withdraw.rs
@@ -34,8 +34,11 @@ async fn main() -> anyhow::Result<()> {
 
     let withdraw = market_ctx.withdraw_base(payer.pubkey(), 100, user_seat.index);
 
-    rpc.send_and_confirm_txn(&payer, &[&payer], &[withdraw])
+    let res = rpc
+        .send_and_confirm_txn(&payer, &[&payer], &[withdraw])
         .await?;
+
+    println!("Transaction signature: {res}");
 
     Ok(())
 }

--- a/client/src/context/market.rs
+++ b/client/src/context/market.rs
@@ -80,6 +80,7 @@ impl MarketContext {
             quote_token_program: self.quote.token_program,
             ata_program: spl_associated_token_account_interface::program::ID,
             system_program: SYSTEM_PROGRAM_ID.into(),
+            dropset_program: dropset::ID.into(),
         }
         .create_instruction(RegisterMarketInstructionData::new(num_sectors))
     }
@@ -110,6 +111,7 @@ impl MarketContext {
             quote_mint: self.quote.mint,
             base_token_program: self.base.token_program,
             quote_token_program: self.quote.token_program,
+            dropset_program: dropset::ID.into(),
         }
         .create_instruction(CloseSeatInstructionData::new(sector_index_hint))
     }
@@ -144,6 +146,7 @@ impl MarketContext {
                 market_ata: self.base_market_ata,
                 mint: self.base.mint,
                 token_program: self.base.token_program,
+                dropset_program: dropset::ID.into(),
             },
             false => Deposit {
                 event_authority: event_authority::ID.into(),
@@ -153,6 +156,7 @@ impl MarketContext {
                 market_ata: self.quote_market_ata,
                 mint: self.quote.mint,
                 token_program: self.quote.token_program,
+                dropset_program: dropset::ID.into(),
             },
         }
         .create_instruction(data)
@@ -168,6 +172,7 @@ impl MarketContext {
                 market_ata: self.base_market_ata,
                 mint: self.base.mint,
                 token_program: self.base.token_program,
+                dropset_program: dropset::ID.into(),
             },
             false => Withdraw {
                 event_authority: event_authority::ID.into(),
@@ -177,6 +182,7 @@ impl MarketContext {
                 market_ata: self.quote_market_ata,
                 mint: self.quote.mint,
                 token_program: self.quote.token_program,
+                dropset_program: dropset::ID.into(),
             },
         }
         .create_instruction(data)

--- a/client/src/pretty/instruction_error.rs
+++ b/client/src/pretty/instruction_error.rs
@@ -115,7 +115,7 @@ impl Display for PrettyInstructionError {
             ),
         };
 
-        let message = format!("{instruction}, {error})");
+        let message = format!("error code: {instruction}, message: {error}");
         let error_message = fmt_kv!(error_type, message, LogColor::Error);
         writeln!(f, "{error_message}")
     }

--- a/interface/src/instructions.rs
+++ b/interface/src/instructions.rs
@@ -23,7 +23,7 @@ use crate::error::DropsetError;
 #[program_id(crate::program::ID)]
 #[rustfmt::skip]
 pub enum DropsetInstruction {
-    #[account(0, signer,   name = "event_authority",      desc = "The event authority PDA signer.")]
+    #[account(0,           name = "event_authority",      desc = "The event authority PDA signer.")]
     #[account(1, signer,   name = "user",                 desc = "The user closing their seat.")]
     #[account(2, writable, name = "market_account",       desc = "The market account PDA.")]
     #[account(3, writable, name = "base_user_ata",        desc = "The user's associated base mint token account.")]
@@ -34,21 +34,23 @@ pub enum DropsetInstruction {
     #[account(8,           name = "quote_mint",           desc = "The quote token mint account.")]
     #[account(9,           name = "base_token_program",   desc = "The base mint's token program.")]
     #[account(10,          name = "quote_token_program",  desc = "The quote mint's token program.")]
+    #[account(11,          name = "dropset_program",      desc = "The dropset program itself, used for the self-CPI.")]
     #[args(sector_index_hint: u32, "A hint indicating which sector the user's seat resides in.")]
     CloseSeat,
 
-    #[account(0, signer,   name = "event_authority", desc = "The event authority PDA signer.")]
+    #[account(0,           name = "event_authority", desc = "The event authority PDA signer.")]
     #[account(1, signer,   name = "user",            desc = "The user depositing or registering their seat.")]
     #[account(2, writable, name = "market_account",  desc = "The market account PDA.")]
     #[account(3, writable, name = "user_ata",        desc = "The user's associated token account.")]
     #[account(4, writable, name = "market_ata",      desc = "The market's associated token account.")]
     #[account(5,           name = "mint",            desc = "The token mint account.")]
     #[account(6,           name = "token_program",   desc = "The mint's token program.")]
+    #[account(7,           name = "dropset_program", desc = "The dropset program itself, used for the self-CPI.")]
     #[args(amount: u64, "The amount to deposit.")]
     #[args(sector_index_hint: u32, "A hint indicating which sector the user's seat resides in (pass `NIL` when registering a new seat).")]
     Deposit,
 
-    #[account(0, signer,   name = "event_authority",     desc = "The event authority PDA signer.")]
+    #[account(0,   name = "event_authority",     desc = "The event authority PDA signer.")]
     #[account(1, signer, writable, name = "user",        desc = "The user registering the market.")]
     #[account(2, writable, name = "market_account",      desc = "The market account PDA.")]
     #[account(3, writable, name = "base_market_ata",     desc = "The market's associated token account for the base mint.")]
@@ -59,16 +61,18 @@ pub enum DropsetInstruction {
     #[account(8,           name = "quote_token_program", desc = "The quote mint's token program.")]
     #[account(9,           name = "ata_program",         desc = "The associated token account program.")]
     #[account(10,          name = "system_program",      desc = "The system program.")]
+    #[account(11,          name = "dropset_program",     desc = "The dropset program itself, used for the self-CPI.")]
     #[args(num_sectors: u16, "The number of sectors to preallocate for the market.")]
     RegisterMarket,
 
-    #[account(0, signer,   name = "event_authority", desc = "The event authority PDA signer.")]
+    #[account(0,           name = "event_authority", desc = "The event authority PDA signer.")]
     #[account(1, signer,   name = "user",            desc = "The user withdrawing.")]
     #[account(2, writable, name = "market_account",  desc = "The market account PDA.")]
     #[account(3, writable, name = "user_ata",        desc = "The user's associated token account.")]
     #[account(4, writable, name = "market_ata",      desc = "The market's associated token account.")]
     #[account(5,           name = "mint",            desc = "The token mint account.")]
     #[account(6,           name = "token_program",   desc = "The mint's token program.")]
+    #[account(7,           name = "dropset_program", desc = "The dropset program itself, used for the self-CPI.")]
     #[args(amount: u64, "The amount to withdraw.")]
     #[args(sector_index_hint: u32, "A hint indicating which sector the user's seat resides in.")]
     Withdraw,

--- a/program/src/context/close_seat_context.rs
+++ b/program/src/context/close_seat_context.rs
@@ -42,6 +42,7 @@ impl<'a> CloseSeatContext<'a> {
             quote_mint,
             base_token_program: _,
             quote_token_program: _,
+            dropset_program: _,
         } = CloseSeat::load_accounts(accounts)?;
 
         // Safety: Scoped borrow of market account data.

--- a/program/src/context/deposit_withdraw_context.rs
+++ b/program/src/context/deposit_withdraw_context.rs
@@ -57,6 +57,7 @@ impl<'a> DepositWithdrawContext<'a> {
             market_ata,
             mint,
             token_program: _,
+            dropset_program: _,
         } = Deposit::load_accounts(accounts)?;
 
         // Safety: Scoped borrow of market account data.
@@ -112,6 +113,7 @@ fn debug_assert_deposit_withdraw(accounts: &[AccountInfo]) {
         market_ata,
         mint,
         token_program,
+        dropset_program,
     } = w.unwrap();
 
     let d = d.unwrap();
@@ -124,4 +126,5 @@ fn debug_assert_deposit_withdraw(accounts: &[AccountInfo]) {
     debug_assert_eq!(d.market_ata.key(), market_ata.key());
     debug_assert_eq!(d.mint.key(), mint.key());
     debug_assert_eq!(d.token_program.key(), token_program.key());
+    debug_assert_eq!(d.dropset_program.key(), dropset_program.key());
 }

--- a/program/src/context/register_market_context.rs
+++ b/program/src/context/register_market_context.rs
@@ -22,7 +22,6 @@ pub struct RegisterMarketContext<'a> {
     pub quote_mint: &'a AccountInfo,
     pub base_token_program: &'a AccountInfo,
     pub quote_token_program: &'a AccountInfo,
-    pub _ata_program: &'a AccountInfo,
     pub system_program: &'a AccountInfo,
 }
 
@@ -38,8 +37,9 @@ impl<'a> RegisterMarketContext<'a> {
             quote_mint,
             base_token_program,
             quote_token_program,
-            ata_program,
+            ata_program: _,
             system_program,
+            dropset_program: _,
         } = RegisterMarket::load_accounts(accounts)?;
 
         // Since the market PDA and both of its associated token accounts are created atomically
@@ -61,7 +61,6 @@ impl<'a> RegisterMarketContext<'a> {
             quote_mint,
             base_token_program,
             quote_token_program,
-            _ata_program: ata_program,
             system_program,
         })
     }

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -22,7 +22,9 @@ program_entrypoint!(process_instruction);
 no_allocator!();
 nostd_panic_handler!();
 
-#[inline(always)]
+// `inline(never)` because the event buffer + batch instruction data causes the program to exceed
+// the 4096 stack frame size very quickly.
+#[inline(never)]
 pub fn process_instruction(
     _program_id: &Pubkey,
     accounts: &[AccountInfo],

--- a/program/src/instructions/batch.rs
+++ b/program/src/instructions/batch.rs
@@ -6,6 +6,7 @@ use pinocchio::{
 };
 
 /// Handler logic for executing multiple instructions in a single atomic batch.
+#[inline(never)]
 pub fn process_batch(_accounts: &[AccountInfo], _instruction_data: &[u8]) -> ProgramResult {
     Ok(())
 }

--- a/program/src/instructions/close_seat.rs
+++ b/program/src/instructions/close_seat.rs
@@ -21,6 +21,7 @@ use crate::{
 /// # Safety
 ///
 /// Caller guarantees the safety contract detailed in [`CloseSeat`].
+#[inline(never)]
 pub fn process_close_seat(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     let sector_index_hint = CloseSeatInstructionData::unpack(instruction_data)?.sector_index_hint;
     let mut ctx = unsafe { CloseSeatContext::load(accounts) }?;

--- a/program/src/instructions/deposit.rs
+++ b/program/src/instructions/deposit.rs
@@ -41,6 +41,7 @@ use crate::{
 /// # Safety
 ///
 /// Caller guarantees the safety contract detailed in [`Deposit`].
+#[inline(never)]
 pub unsafe fn process_deposit(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     let DepositInstructionData {
         amount,

--- a/program/src/instructions/flush_events.rs
+++ b/program/src/instructions/flush_events.rs
@@ -6,6 +6,7 @@ use pinocchio::{
 };
 
 /// Handler logic for flushing/consuming pending intra-transaction events associated with a market.
+#[inline(never)]
 pub fn process_flush_events(_accounts: &[AccountInfo], _instruction_data: &[u8]) -> ProgramResult {
     Ok(())
 }

--- a/program/src/instructions/register_market.rs
+++ b/program/src/instructions/register_market.rs
@@ -31,6 +31,7 @@ use crate::{
 /// # Safety
 ///
 /// Caller guarantees the safety contract detailed in [`RegisterMarket`].
+#[inline(never)]
 pub unsafe fn process_register_market(
     accounts: &[AccountInfo],
     instruction_data: &[u8],

--- a/program/src/instructions/withdraw.rs
+++ b/program/src/instructions/withdraw.rs
@@ -23,6 +23,7 @@ use crate::{
 /// # Safety
 ///
 /// Caller guarantees the safety contract detailed in [`Withdraw`].
+#[inline(never)]
 pub unsafe fn process_withdraw(accounts: &[AccountInfo], instruction_data: &[u8]) -> ProgramResult {
     let WithdrawInstructionData {
         amount,


### PR DESCRIPTION
# Description

The accounts list portion of this PR was erroneously not included in #45. With these new changes, each instruction properly runs and can emit event data in #44.

`dropset_program` must be included in the list of accounts, even if it's never used or needed. This is because CPI invocations require that the program is in the account metas list.

Inlining the instruction handlers is to avoid exceeding the max stack frame size (`4096` bytes). With the event buffer + eventual batch instructions, `inline(always)` should generally only be applied to more granularly scoped control flow/helper functions.

- [X] Add `dropset_program` to each instruction's account list
- [X] `inline(always)` instruction handlers