### PR TITLE
[ENG-122] Fix broken doc links

### DIFF
--- a/price/src/lib.rs
+++ b/price/src/lib.rs
@@ -90,6 +90,7 @@ pub struct OrderInfo {
 ///
 /// [`tests::ensure_invalid_quote_exponent_fails_early`] ensures that the function fails early if
 /// the quote exponent isn't <= MAX_BIASED_EXPONENT prior to the unchecked add.
+#[allow(rustdoc::broken_intra_doc_links)]
 pub fn to_order_info(
     price_mantissa: u32,
     base_scalar: u64,

--- a/program/src/context/flush_events_context.rs
+++ b/program/src/context/flush_events_context.rs
@@ -8,7 +8,7 @@ use pinocchio::{
 
 use crate::validation::event_authority::EventAuthorityInfo;
 
-/// The account context for the [`dropset_interface::`] instruction.
+/// The account context for the [`FlushEvents`] instruction.
 #[derive(Clone)]
 pub struct FlushEventsContext<'a> {
     pub _event_authority: EventAuthorityInfo<'a>,

--- a/program/src/events.rs
+++ b/program/src/events.rs
@@ -36,7 +36,7 @@ pub const EVENT_BUFFER_LEN: usize = 1024;
 /// Self-CPIs on event instruction data facilitates emitting events
 /// without having to store it in account data.
 ///
-/// The buffer `data` always begins with a [`HeaderInstructionData`]
+/// The buffer `data` always begins with a [`HeaderEventInstructionData`]
 /// event, tracking the number of events currently stored in the buffer
 /// and other various info about the transaction/instruction.
 ///
@@ -52,10 +52,10 @@ pub struct EventBuffer {
     /// The stack-allocated, possibly initialized buffer bytes.
     ///
     /// The layout for the data is:
-    /// - `[0]`: the instruction tag of the instruction that created this event buffer.
-    /// - `[1..HeaderInstructionData::LEN_WITH_TAG]`: the header instruction data.
-    /// - `[HeaderInstructionData::LEN_WITH_TAG..]`: the byte data for the other non-header events
-    ///   in the buffer.
+    /// - \[0\]: the instruction tag of the instruction that created this event buffer.
+    /// - [1..[HeaderEventInstructionData::LEN_WITH_TAG]]: the header instruction data.
+    /// - [[HeaderEventInstructionData::LEN_WITH_TAG]..]: the byte data for the other non-header
+    ///   events in the buffer.
     pub data: [MaybeUninit<u8>; EVENT_BUFFER_LEN],
     /// The number of events in the buffer that come after the header.
     emitted_count: u16,

--- a/program/src/instructions/batch.rs
+++ b/program/src/instructions/batch.rs
@@ -6,6 +6,12 @@ use pinocchio::{
 };
 
 /// Handler logic for executing multiple instructions in a single atomic batch.
+///
+/// # Safety
+///
+/// Since the accounts borrowed depend on the inner batch instructions, the most straightforward
+/// safety contract is simply ensuring that **no Solana account data is currently borrowed** prior
+/// to calling this instruction.
 #[inline(never)]
 pub fn process_batch(_accounts: &[AccountInfo], _instruction_data: &[u8]) -> ProgramResult {
     Ok(())

--- a/program/src/instructions/close_seat.rs
+++ b/program/src/instructions/close_seat.rs
@@ -25,7 +25,8 @@ use crate::{
 ///
 /// # Safety
 ///
-/// Caller guarantees the safety contract detailed in [`CloseSeat`].
+/// Caller guarantees the safety contract detailed in
+/// [`dropset_interface::instructions::generated_pinocchio::CloseSeat`].
 #[inline(never)]
 pub fn process_close_seat<'a>(
     accounts: &'a [AccountInfo],

--- a/program/src/instructions/deposit.rs
+++ b/program/src/instructions/deposit.rs
@@ -44,7 +44,8 @@ use crate::{
 ///
 /// # Safety
 ///
-/// Caller guarantees the safety contract detailed in [`Deposit`].
+/// Caller guarantees the safety contract detailed in
+/// [`dropset_interface::instructions::generated_pinocchio::Deposit`].
 #[inline(never)]
 pub unsafe fn process_deposit<'a>(
     accounts: &'a [AccountInfo],

--- a/program/src/instructions/register_market.rs
+++ b/program/src/instructions/register_market.rs
@@ -36,7 +36,8 @@ use crate::{
 ///
 /// # Safety
 ///
-/// Caller guarantees the safety contract detailed in [`RegisterMarket`].
+/// Caller guarantees the safety contract detailed in
+/// [`dropset_interface::instructions::generated_pinocchio::RegisterMarket`].
 #[inline(never)]
 pub unsafe fn process_register_market<'a>(
     accounts: &'a [AccountInfo],

--- a/program/src/instructions/withdraw.rs
+++ b/program/src/instructions/withdraw.rs
@@ -27,7 +27,8 @@ use crate::{
 ///
 /// # Safety
 ///
-/// Caller guarantees the safety contract detailed in [`Withdraw`].
+/// Caller guarantees the safety contract detailed in
+/// [`dropset_interface::instructions::generated_pinocchio::Withdraw`].
 #[inline(never)]
 pub unsafe fn process_withdraw<'a>(
     accounts: &'a [AccountInfo],


### PR DESCRIPTION
# Description

Fairly self explanatory.

To verify, run:

```shell
cargo doc --no-deps --document-private-items --workspace
```
