### PR TITLE
[ENG-178] Refactor `CustomRpcClient` to use the nonblocking Solana RPC client

### DIFF
--- a/bots/crates/market-maker/examples/initialization_helper.rs
+++ b/bots/crates/market-maker/examples/initialization_helper.rs
@@ -64,7 +64,8 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     let seat = e2e
-        .find_seat(&maker_address)?
+        .fetch_seat(&maker_address)
+        .await?
         .expect("Should have a seat")
         .index;
 
@@ -80,7 +81,8 @@ async fn main() -> anyhow::Result<()> {
         maker_keypair: maker.insecure_clone().to_base58_string(),
         market: e2e.market.market,
         maker_seat: e2e
-            .view_market()?
+            .view_market()
+            .await?
             .seats
             .iter()
             .find(|s| s.user == maker_address)

--- a/bots/crates/market-maker/src/cli.rs
+++ b/bots/crates/market-maker/src/cli.rs
@@ -77,4 +77,5 @@ pub async fn initialize_context_from_cli(
         target_base,
         initial_price_feed_response,
     )
+    .await
 }

--- a/bots/crates/market-maker/src/main.rs
+++ b/bots/crates/market-maker/src/main.rs
@@ -31,10 +31,7 @@ use solana_client::{
     },
 };
 use strum_macros::Display;
-use tokio::{
-    sync::watch,
-    time::sleep,
-};
+use tokio::sync::watch;
 use tokio_stream::StreamExt;
 use transaction_parser::views::try_market_view_all_from_owner_and_data;
 
@@ -241,6 +238,6 @@ async fn throttled_order_update(
 
         // Sleep for the throttle window in milliseconds before doing work again.
         // This effectively means the loop only does the cancel/post work once every window of time.
-        sleep(Duration::from_millis(throttle_window_ms)).await;
+        tokio::time::sleep(Duration::from_millis(throttle_window_ms)).await;
     }
 }

--- a/bots/crates/market-maker/src/maker_context/mod.rs
+++ b/bots/crates/market-maker/src/maker_context/mod.rs
@@ -67,7 +67,7 @@ pub struct MakerContext {
 
 impl MakerContext {
     /// Creates a new maker context from a token pair.
-    pub fn init(
+    pub async fn init(
         rpc: &CustomRpcClient,
         maker: Keypair,
         base_mint: Address,
@@ -77,8 +77,8 @@ impl MakerContext {
         initial_price_feed_response: OandaCandlestickResponse,
     ) -> anyhow::Result<Self> {
         let market_ctx =
-            MarketContext::new_from_token_pair(rpc, base_mint, quote_mint, None, None)?;
-        let market = market_ctx.view_market(rpc)?;
+            MarketContext::new_from_token_pair(rpc, base_mint, quote_mint, None, None).await?;
+        let market = market_ctx.view_market(rpc).await?;
         let latest_state = MakerState::new_from_market(maker.pubkey(), market)?;
         let mid_price = get_normalized_mid_price(initial_price_feed_response, &pair, &market_ctx)?;
         let maker_address = maker.pubkey();

--- a/client/examples/close_seat.rs
+++ b/client/examples/close_seat.rs
@@ -38,11 +38,12 @@ async fn main() -> anyhow::Result<()> {
         .send_single_signer(&e2e.rpc, &trader)
         .await?;
 
-    let market = e2e.view_market()?;
+    let market = e2e.view_market().await?;
     print_kv!("Seats before", market.header.num_seats, LogColor::Info);
 
     let user_seat = e2e
-        .find_seat(&trader.pubkey())?
+        .fetch_seat(&trader.pubkey())
+        .await?
         .expect("User should have been registered on deposit");
 
     e2e.market
@@ -50,7 +51,7 @@ async fn main() -> anyhow::Result<()> {
         .send_single_signer(&e2e.rpc, &trader)
         .await?;
 
-    let market = e2e.view_market()?;
+    let market = e2e.view_market().await?;
     print_kv!("Seats after", market.header.num_seats, LogColor::Info);
 
     Ok(())

--- a/client/examples/deposit_and_withdraw.rs
+++ b/client/examples/deposit_and_withdraw.rs
@@ -18,10 +18,11 @@ async fn main() -> anyhow::Result<()> {
         .send_single_signer(&e2e.rpc, &trader)
         .await?;
 
-    println!("{:#?}", e2e.view_market());
+    println!("{:#?}", e2e.view_market().await?);
 
     let user_seat = e2e
-        .find_seat(&trader.pubkey())?
+        .fetch_seat(&trader.pubkey())
+        .await?
         .expect("User should have been registered on deposit");
 
     let res = e2e

--- a/client/examples/post_and_cancel.rs
+++ b/client/examples/post_and_cancel.rs
@@ -44,10 +44,11 @@ async fn main() -> anyhow::Result<()> {
         .send_single_signer(&e2e.rpc, trader)
         .await?;
 
-    println!("Market after user deposit\n{:#?}", e2e.view_market()?);
+    println!("Market after user deposit\n{:#?}", e2e.view_market().await?);
 
     let user_seat = e2e
-        .find_seat(&trader.pubkey())?
+        .fetch_seat(&trader.pubkey())
+        .await?
         .expect("User should have been registered on deposit");
 
     let order_info_args = OrderInfoArgs::new(
@@ -75,9 +76,12 @@ async fn main() -> anyhow::Result<()> {
         post_ask_res.parsed_transaction.signature
     );
 
-    println!("Market after posting user ask:\n{:#?}", e2e.view_market()?);
+    println!(
+        "Market after posting user ask:\n{:#?}",
+        e2e.view_market().await?
+    );
 
-    let user_seat = e2e.find_seat(&trader.pubkey())?.unwrap();
+    let user_seat = e2e.fetch_seat(&trader.pubkey()).await?.unwrap();
     println!("User seat after posting ask: {user_seat:#?}");
 
     let cancel_ask_res = e2e
@@ -98,10 +102,13 @@ async fn main() -> anyhow::Result<()> {
         cancel_ask_res.parsed_transaction.signature
     );
 
-    let user_seat = e2e.find_seat(&trader.pubkey())?.unwrap();
+    let user_seat = e2e.fetch_seat(&trader.pubkey()).await?.unwrap();
     println!("User seat after canceling ask: {user_seat:#?}");
 
-    println!("Market after canceling user ask:\n{:#?}", e2e.view_market());
+    println!(
+        "Market after canceling user ask:\n{:#?}",
+        e2e.view_market().await?
+    );
 
     Ok(())
 }

--- a/client/examples/post_asks.rs
+++ b/client/examples/post_asks.rs
@@ -41,10 +41,11 @@ async fn main() -> anyhow::Result<()> {
         .send_single_signer(&e2e.rpc, trader)
         .await?;
 
-    println!("Market after user deposit\n{:#?}", e2e.view_market()?);
+    println!("Market after user deposit\n{:#?}", e2e.view_market().await?);
 
     let user_seat = e2e
-        .find_seat(&trader.pubkey())?
+        .fetch_seat(&trader.pubkey())
+        .await?
         .expect("User should have been registered on deposit");
 
     let order_info_args = OrderInfoArgs::new(
@@ -70,9 +71,12 @@ async fn main() -> anyhow::Result<()> {
         post_ask_res.parsed_transaction.signature
     );
 
-    println!("Market after posting user ask:\n{:#?}", e2e.view_market()?);
+    println!(
+        "Market after posting user ask:\n{:#?}",
+        e2e.view_market().await?
+    );
 
-    let user_seat = e2e.find_seat(&trader.pubkey())?.unwrap();
+    let user_seat = e2e.fetch_seat(&trader.pubkey()).await?.unwrap();
     println!("User seat after posting ask: {user_seat:#?}");
 
     // Post an ask. The user provides base as collateral and receives quote when filled.
@@ -104,10 +108,10 @@ async fn main() -> anyhow::Result<()> {
 
     println!(
         "Market after posting many user asks:\n{:#?}",
-        e2e.view_market()?
+        e2e.view_market().await?
     );
 
-    let user_seat = e2e.find_seat(&trader.pubkey())?.unwrap();
+    let user_seat = e2e.fetch_seat(&trader.pubkey()).await?.unwrap();
     println!("User seat after posting many asks: {user_seat:#?}");
 
     Ok(())

--- a/client/examples/two_seats.rs
+++ b/client/examples/two_seats.rs
@@ -31,7 +31,7 @@ async fn main() -> anyhow::Result<()> {
         .send_single_signer(&e2e.rpc, payer_1)
         .await?;
 
-    let market = e2e.view_market()?;
+    let market = e2e.view_market().await?;
 
     // Sanity check.
     assert!(payer_1.pubkey() != payer_2.pubkey());

--- a/client/src/e2e_helpers/mod.rs
+++ b/client/src/e2e_helpers/mod.rs
@@ -112,19 +112,24 @@ impl E2e {
         })
     }
 
-    pub fn view_market(&self) -> anyhow::Result<MarketViewAll> {
-        self.market.view_market(&self.rpc)
+    pub async fn view_market(&self) -> anyhow::Result<MarketViewAll> {
+        self.market.view_market(&self.rpc).await
     }
 
-    pub fn find_seat(&self, user: &Address) -> anyhow::Result<Option<MarketSeatView>> {
-        self.market.find_seat(&self.rpc, user)
+    pub async fn fetch_seat(&self, user: &Address) -> anyhow::Result<Option<MarketSeatView>> {
+        let market = self.view_market().await?;
+        Ok(self.find_seat(&market.seats, user))
     }
 
-    pub fn get_base_balance(&self, user: &Address) -> anyhow::Result<u64> {
-        self.market.base.get_balance_for(&self.rpc, user)
+    pub fn find_seat(&self, seats: &[MarketSeatView], user: &Address) -> Option<MarketSeatView> {
+        self.market.find_seat(seats, user)
     }
 
-    pub fn get_quote_balance(&self, user: &Address) -> anyhow::Result<u64> {
-        self.market.quote.get_balance_for(&self.rpc, user)
+    pub async fn get_base_balance(&self, user: &Address) -> anyhow::Result<u64> {
+        self.market.base.get_balance_for(&self.rpc, user).await
+    }
+
+    pub async fn get_quote_balance(&self, user: &Address) -> anyhow::Result<u64> {
+        self.market.quote.get_balance_for(&self.rpc, user).await
     }
 }

--- a/grpc-stream/src/main.rs
+++ b/grpc-stream/src/main.rs
@@ -12,10 +12,7 @@ use grpc_stream::parse_update::{
     InstructionEventsWithIndices,
     ParsedUpdate,
 };
-use tokio::time::{
-    sleep,
-    Duration,
-};
+use tokio::time::Duration;
 use yellowstone_grpc_client::GeyserGrpcClient;
 use yellowstone_grpc_proto::{
     geyser::{
@@ -112,7 +109,7 @@ async fn main() -> anyhow::Result<()> {
             }
             Err(error) => {
                 eprintln!("❌ Stream error: {}", error);
-                sleep(Duration::from_secs(1)).await;
+                tokio::time::sleep(Duration::from_secs(1)).await;
             }
         }
     }


### PR DESCRIPTION
# Description

The blocking RPC client is nice to use for simple examples where the usage of async isn't necessary or warranted, but since it's being used in the market maker bot and will likely be used in other more complex scenarios, it's worth refactoring it to use the nonblocking client. This means refactoring each function that is blocking to being async instead.

In some cases these functions were misleadingly marked as `async` but were actually blocking on IO synchronously between `.await` points, so this design is not only more honest, but more efficient. For example, this improves the market maker bot performance since the blocking network calls are no longer starving other tasks while waiting on responses.

This also fixes the issue with the `[tokio::main(flavor = "current_thread")` flag causing issues in the example, since you can't call `block_in_place` from `"current_thread"`, and that's what the `RpcClient` was doing internally.