### PR TITLE
build: add additional commands to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "scripts": {
-    "build-deps": "cargo build --workspace", 
-    "build-dev-deps": "cargo +nightly install cargo-expand", 
+    "build-deps": "cargo build --workspace",
+    "build-dev-deps": "cargo +nightly install cargo-expand",
     "build": "cd program && cargo build-sbf",
     "bench:manifest": "bash cu-bench/manifest/run-bench.sh",
     "bench:phoenix": "bash cu-bench/phoenix/run-bench.sh",
     "build:debug": "cd program && cargo build-sbf --features debug",
-    "check": "cargo check", 
-    "clean": "cargo clean", 
+    "check": "cargo check",
+    "clean": "cargo clean",
     "clippy": "cargo clippy --all-targets -- -D warnings",
     "deploy": "solana program deploy target/deploy/dropset.so --program-id test-keypair.json || echo 'Make sure the local validator is running'",
     "examples:register_market": "cargo run --example register_market",
@@ -18,7 +18,7 @@
     "examples:post_asks": "cargo run --example post_asks",
     "examples:post_and_cancel": "cargo run --example post_and_cancel",
     "examples:two_seats": "cargo run --example two_seats",
-    "format": "cargo +nightly fmt --all", 
+    "format": "cargo +nightly fmt --all",
     "test": "cargo test"
   }
 }


### PR DESCRIPTION
Hoping to work with and contribute more to this repository. Starting with getting the workflow to be a lot easier for me. 

This PR adds a few `cargo` commands to `package.json`:
- build-deps: cargo build --workspace
- build-dev-deps: cargo +nightly install cargo-expand
- check: cargo check
- clean: cargo clean
- clippy: cargo clippy --all-targets -- -D warnings
- format: cargo +nightly fmt --all