### PR TITLE
derive Transmutable for sector-backed types

### DIFF
--- a/instruction-macros/crates/instruction-macros-derive/src/derive/mod.rs
+++ b/instruction-macros/crates/instruction-macros-derive/src/derive/mod.rs
@@ -7,6 +7,7 @@ mod codama_type;
 mod instruction_accounts;
 mod instruction_data;
 mod pack;
+mod transmutable;
 mod unpack;
 
 pub use codama_events::*;
@@ -15,4 +16,5 @@ pub use codama_type::*;
 pub use instruction_accounts::*;
 pub use instruction_data::*;
 pub use pack::*;
+pub use transmutable::*;
 pub use unpack::*;

--- a/instruction-macros/crates/instruction-macros-derive/src/derive/transmutable.rs
+++ b/instruction-macros/crates/instruction-macros-derive/src/derive/transmutable.rs
@@ -1,0 +1,47 @@
+//! Derive helper for the [`crate::Transmutable`] trait.
+
+use instruction_macros_impl::parse::data_struct::require_data_struct;
+use proc_macro2::TokenStream;
+use quote::quote;
+use syn::{punctuated::Punctuated, DeriveInput, Meta, Token};
+
+fn has_repr_c_or_transparent(input: &DeriveInput) -> bool {
+    for attr in &input.attrs {
+        if !attr.path().is_ident("repr") {
+            continue;
+        }
+        if let Ok(nested) = attr.parse_args_with(Punctuated::<Meta, Token![,]>::parse_terminated) {
+            if nested
+                .iter()
+                .any(|m| m.path().is_ident("C") || m.path().is_ident("transparent"))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+pub fn derive_transmutable(input: DeriveInput) -> syn::Result<TokenStream> {
+    let struct_ident = input.ident.clone();
+
+    if !has_repr_c_or_transparent(&input) {
+        return Err(syn::Error::new_spanned(
+            &struct_ident,
+            "Transmutable requires `#[repr(C)]` or `#[repr(transparent)]`",
+        ));
+    }
+
+    require_data_struct(input)?;
+
+    Ok(quote! {
+        unsafe impl crate::state::transmutable::Transmutable for #struct_ident {
+            const LEN: usize = ::core::mem::size_of::<Self>();
+
+            #[inline(always)]
+            fn validate_bit_patterns(_bytes: &[u8]) -> crate::error::DropsetResult {
+                Ok(())
+            }
+        }
+    })
+}

--- a/instruction-macros/crates/instruction-macros-derive/src/lib.rs
+++ b/instruction-macros/crates/instruction-macros-derive/src/lib.rs
@@ -28,6 +28,7 @@ use crate::derive::{
     derive_codama_program,
     derive_codama_type,
     derive_pack,
+    derive_transmutable,
     derive_unpack,
 };
 
@@ -141,6 +142,20 @@ pub fn codama_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     debug_paths_if_env_var_set(&[&codama_impl]);
 
     codama_impl.into()
+}
+
+/// The entrypoint for the proc macro derive [`Transmutable`].
+#[proc_macro_derive(Transmutable)]
+pub fn transmutable(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+
+    let transmutable_impl = match derive_transmutable(input) {
+        Ok(render) => render,
+        Err(e) => return e.into_compile_error().into(),
+    };
+
+    debug_paths_if_env_var_set(&[&transmutable_impl]);
+    transmutable_impl.into()
 }
 
 /// Generates a [`CodamaProgram`] impl on an instruction enum

--- a/interface/src/state/order.rs
+++ b/interface/src/state/order.rs
@@ -99,7 +99,7 @@ pub const ORDER_PADDING: usize =
 
 /// Represents a maker order in the order book.
 #[repr(C)]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, instruction_macros::Transmutable)]
 pub struct Order {
     /// The LE bytes representing an [`EncodedPrice`].
     encoded_price: LeEncodedPrice,
@@ -178,21 +178,6 @@ impl Order {
     #[inline(always)]
     pub fn as_bytes(&self) -> &[u8; Self::LEN] {
         unsafe { &*(self as *const Self as *const [u8; Self::LEN]) }
-    }
-}
-
-// Safety:
-//
-// - Stable layout with `#[repr(C)]`.
-// - `size_of` and `align_of` are checked below.
-// - All bit patterns are valid.
-unsafe impl Transmutable for Order {
-    const LEN: usize = size_of::<Order>();
-
-    #[inline(always)]
-    fn validate_bit_patterns(_bytes: &[u8]) -> crate::error::DropsetResult {
-        // All bit patterns are valid: no enums, bools, or other types with invalid states.
-        Ok(())
     }
 }
 


### PR DESCRIPTION
Adds #[derive(Transmutable)] to types that live in raw sector memory

Currently there is a lot of casting from &[u8] > structs (e.g. Sector, Order, MarketSeat). these types need to be raw and have a fixed size, so Transmutable gives T::LEN

Makes sure:
- Fixed size at compile time
- Contains no invalid bit patterns
- Type can be converted into raw bytes

without this, stuff like

```rust
self.sectors.len() / Sector::LEN
```

wont compile.

also, got rid of a prev impl for this for the Order struct