### PR TITLE
Fix cu_market_order crash on fill market order

### DIFF
--- a/interface/src/events/tests.rs
+++ b/interface/src/events/tests.rs
@@ -3,6 +3,11 @@ use strum::IntoEnumIterator;
 extern crate std;
 use std::collections::HashSet;
 
+use instruction_macros::{
+    Pack,
+    Tagged,
+};
+
 use super::*;
 
 #[test]
@@ -37,4 +42,19 @@ fn test_ixn_tag_try_from_u8_exhaustive() {
             );
         }
     }
+}
+
+#[test]
+fn test_fill_event_tagged_len_matches_written_bytes() {
+    let event = FillEventInstructionData::new(true, false, 11, 22, 33);
+
+    let untagged = event.pack();
+    let tagged = event.pack_tagged();
+
+    assert_eq!(FillEventInstructionData::LEN, 22);
+    assert_eq!(FillEventInstructionData::LEN_WITH_TAG, FillEventInstructionData::LEN + 1);
+    assert_eq!(untagged.len(), FillEventInstructionData::LEN);
+    assert_eq!(tagged.len(), FillEventInstructionData::LEN_WITH_TAG);
+    assert_eq!(tagged[0], FillEventInstructionData::TAG_BYTE);
+    assert_eq!(&tagged[1..], untagged.as_ref());
 }

--- a/interface/src/state/linked_list.rs
+++ b/interface/src/state/linked_list.rs
@@ -11,6 +11,7 @@ use crate::{
             NIL,
             PAYLOAD_SIZE,
         },
+        transmutable::Transmutable,
     },
 };
 
@@ -160,7 +161,7 @@ impl<'a, T: LinkedListHeaderOperations> LinkedList<'a, T> {
         Ok(new_index)
     }
 
-    /// Removes the sector at the non-NIL sector `index` without checking the index validity.
+    /// Removes the sector at the non-NIL sector `index` after checking the index validity.
     ///
     /// # Safety
     ///
@@ -170,6 +171,7 @@ impl<'a, T: LinkedListHeaderOperations> LinkedList<'a, T> {
         let num_sectors = self.sectors.len() / Sector::LEN;
         assert!((index as usize) < num_sectors);
         let (prev_index, next_index) = {
+            // Safety: Caller guarantees `index` is in-bounds.
             let sector = unsafe { Sector::from_sector_index_mut(self.sectors, index) };
             let prev = sector.prev();
             let next = sector.next();
@@ -181,13 +183,6 @@ impl<'a, T: LinkedListHeaderOperations> LinkedList<'a, T> {
             }
             (prev, next)
         };
-
-        /*let (prev_index, next_index) = {
-            // Safety: Caller guarantees `index` is in-bounds.
-            let sector = unsafe { Sector::from_sector_index_mut(self.sectors, index) };
-            (sector.prev(), sector.next())
-        };
-        */
 
         match prev_index {
             NIL => T::set_head(self.header, next_index),

--- a/interface/src/state/linked_list.rs
+++ b/interface/src/state/linked_list.rs
@@ -1,5 +1,7 @@
 use core::marker::PhantomData;
 
+use crate::state::transmutable::Transmutable;
+
 use crate::{
     error::DropsetError,
     state::{
@@ -166,11 +168,28 @@ impl<'a, T: LinkedListHeaderOperations> LinkedList<'a, T> {
     ///
     /// Caller guarantees `index` is in-bounds.
     pub unsafe fn remove_at(&mut self, index: SectorIndex) {
+
+        let num_sectors = self.sectors.len() / Sector::LEN;
+        assert!((index as usize) < num_sectors);
         let (prev_index, next_index) = {
+            let sector = unsafe { Sector::from_sector_index_mut(self.sectors, index) };
+            let prev = sector.prev();
+            let next = sector.next();
+            if prev != NIL {
+                assert!((prev as usize) < num_sectors);
+            }
+            if next != NIL {
+                assert!((next as usize) < num_sectors);
+            }
+            (prev, next)
+        };
+
+        /*let (prev_index, next_index) = {
             // Safety: Caller guarantees `index` is in-bounds.
             let sector = unsafe { Sector::from_sector_index_mut(self.sectors, index) };
             (sector.prev(), sector.next())
         };
+        */
 
         match prev_index {
             NIL => T::set_head(self.header, next_index),

--- a/interface/src/state/linked_list.rs
+++ b/interface/src/state/linked_list.rs
@@ -1,7 +1,5 @@
 use core::marker::PhantomData;
 
-use crate::state::transmutable::Transmutable;
-
 use crate::{
     error::DropsetError,
     state::{

--- a/program/src/entrypoint.rs
+++ b/program/src/entrypoint.rs
@@ -40,6 +40,23 @@ pub fn process_instruction(
 
     let instruction_tag = DropsetInstruction::try_from(*tag)?;
 
+    if matches!(
+        instruction_tag,
+        DropsetInstruction::FlushEvents | DropsetInstruction::BatchReplace
+    ) {
+        // these instruction handlers do not use the stack-allocated event buffer
+        //try not to create it for self-CPIs so the nested frame stays as small as possible
+        return unsafe {
+            match instruction_tag {
+                DropsetInstruction::FlushEvents => process_flush_events(accounts, instruction_data),
+                DropsetInstruction::BatchReplace => {
+                    process_batch_replace(accounts, instruction_data)
+                }
+                _ => unreachable!(),
+            }
+        };
+    }
+
     let event_buffer = &mut EventBuffer::new(instruction_tag);
 
     // Safety: No account data is currently borrowed. CPIs to this program must ensure they do not
@@ -67,12 +84,7 @@ pub fn process_instruction(
             DropsetInstruction::MarketOrder => {
                 process_market_order(accounts, instruction_data, event_buffer)
             }
-            DropsetInstruction::FlushEvents => {
-                return process_flush_events(accounts, instruction_data)
-            }
-            DropsetInstruction::BatchReplace => {
-                return process_batch_replace(accounts, instruction_data)
-            }
+            DropsetInstruction::FlushEvents | DropsetInstruction::BatchReplace => unreachable!(),
             DropsetInstruction::ExpandMarket => {
                 process_expand_market(accounts, instruction_data, event_buffer)
             }

--- a/program/src/events.rs
+++ b/program/src/events.rs
@@ -15,6 +15,7 @@ use instruction_macros_traits::Tagged;
 use pinocchio::{
     account::AccountView,
     cpi::invoke_signed,
+    error::ProgramError,
     hint::unlikely,
     ProgramResult,
 };
@@ -72,7 +73,7 @@ const HEADER_DATA_OFFSET: usize = 1;
 /// tag + the header instruction event data.
 ///
 /// This is essentially where the emitted events data actually starts.
-const HEADER_SIZE_WITH_TAGS: usize =
+pub(crate) const HEADER_SIZE_WITH_TAGS: usize =
     size_of::<DropsetInstruction>() + HeaderEventInstructionData::LEN_WITH_TAG;
 
 impl EventBuffer {
@@ -122,9 +123,13 @@ impl EventBuffer {
         }
 
         let market_address = *market_account.account().address();
-        // Safety: `market_account` is not currently borrowed in any capacity.
-        let market_ref_mut = unsafe { market_account.load_unchecked_mut() };
-        market_ref_mut.header.increment_num_events_by(emitted_count);
+        let total_emitted_events = {
+            // scope the mutable market borrow so the nested self-CPI does not re-enter while the
+            // outer frame still holds an active mutable reference into the same account data
+            let market_ref_mut = unsafe { market_account.load_unchecked_mut() };
+            market_ref_mut.header.increment_num_events_by(emitted_count);
+            market_ref_mut.header.num_events()
+        };
 
         // Safety:
         // The header prefix bytes have already been zeroed, so `self.data` is long enough.
@@ -134,7 +139,7 @@ impl EventBuffer {
             HeaderEventInstructionData::new(
                 self.instruction_tag as u8,
                 self.emitted_count,
-                market_ref_mut.header.num_events(),
+                total_emitted_events,
                 market_address,
             )
             .write_bytes_tagged(self.data.as_mut_ptr().add(HEADER_DATA_OFFSET) as *mut u8);
@@ -169,15 +174,24 @@ impl EventBuffer {
         event_authority: &'a AccountView,
         market_account: MarketAccountView<'a>,
     ) -> ProgramResult {
-        let len: usize = self.len;
-        if len + T::LEN_WITH_TAG > EVENT_BUFFER_LEN {
+        crate::debug!("event_buffer.len: {}", self.len);
+        crate::debug!("event.size: {}", T::LEN_WITH_TAG);
+        crate::debug!("event_buffer.cap: {}", EVENT_BUFFER_LEN);
+
+        if self.len + T::LEN_WITH_TAG > EVENT_BUFFER_LEN {
             // Safety: `market_account` is not currently borrowed in any capacity.
             unsafe { self.flush_events(event_authority, market_account) }?;
         }
 
+        let len = self.len;
+
         // Since the length isn't checked again after flushing, check the very unlikely
         // edge case that we've defined an event that's larger than the size of a newly
         // flushed event buffer.
+        if len + T::LEN_WITH_TAG > EVENT_BUFFER_LEN {
+            return Err(ProgramError::InvalidInstructionData);
+        }
+
         debug_assert!(
             T::LEN_WITH_TAG < EVENT_BUFFER_LEN - HEADER_SIZE_WITH_TAGS,
             "Event is way too big"

--- a/program/src/instructions/market_order/fill_market_order.rs
+++ b/program/src/instructions/market_order/fill_market_order.rs
@@ -82,7 +82,7 @@ pub struct AmountsFilled {
 /// # Safety
 ///
 /// The market account data must not be currently borrowed.
-#[inline(always)]
+#[inline(never)]
 pub unsafe fn fill_market_order<const IS_BUY: bool, const BASE_DENOM: bool>(
     ctx: &'_ mut MarketOrderContext<'_>,
     event_buffer: &mut EventBuffer,
@@ -201,7 +201,7 @@ fn top_of_book_snapshot<const IS_BUY: bool>(ctx: &'_ MarketOrderContext) -> Opti
 /// user seat sector index must both still point to valid, properly typed sectors in memory.
 ///
 /// The constraint asset remaining must be <= the top order's constraint asset remaining.
-#[inline(always)]
+#[inline(never)]
 unsafe fn full_fill<const IS_BUY: bool, const BASE_DENOM: bool>(
     ctx: &'_ mut MarketOrderContext<'_>,
     event_buffer: &mut EventBuffer,
@@ -211,15 +211,15 @@ unsafe fn full_fill<const IS_BUY: bool, const BASE_DENOM: bool>(
 ) -> ProgramResult {
     // 1. Close/remove the order from the orders collection.
     if IS_BUY {
-        ctx.market_account
-            .load_unchecked_mut()
-            .asks()
-            .remove_at(top_order.order_sector);
+        {
+            let mut market = ctx.market_account.load_unchecked_mut();
+            market.asks().remove_at(top_order.order_sector);
+        }
     } else {
-        ctx.market_account
-            .load_unchecked_mut()
-            .bids()
-            .remove_at(top_order.order_sector);
+        {
+            let mut market = ctx.market_account.load_unchecked_mut();
+            market.bids().remove_at(top_order.order_sector);
+        }
     }
 
     // 2. Update the filled maker seat's balance and remove the order from their price to order
@@ -262,7 +262,7 @@ unsafe fn full_fill<const IS_BUY: bool, const BASE_DENOM: bool>(
     Ok(())
 }
 
-#[inline(always)]
+#[inline(never)]
 fn partial_fill<const IS_BUY: bool, const BASE_DENOM: bool>(
     ctx: &'_ mut MarketOrderContext<'_>,
     event_buffer: &mut EventBuffer,
@@ -359,7 +359,7 @@ fn dropset_non_zero_u64(value: u64) -> Result<NonZeroU64, DropsetError> {
 ///
 /// The market account data must not be currently borrowed and the passed order's maker seat sector
 /// index must still point to a valid seat in memory.
-#[inline(always)]
+#[inline(never)]
 unsafe fn update_maker_seat_after_fill<const IS_BUY: bool, const PARTIAL_FILL: bool>(
     ctx: &'_ mut MarketOrderContext<'_>,
     maker_seat_sector: SectorIndex,

--- a/program/src/instructions/market_order/mod.rs
+++ b/program/src/instructions/market_order/mod.rs
@@ -62,51 +62,10 @@ pub unsafe fn process_market_order<'a>(
 
     // Try to transfer the taker side's tokens to the market account.
     // Safety: No account data is currently borrowed.
-    let (taker_amount_filled, taker_amount_deposited) = unsafe {
-        // A buy means taker transfers quote to the market.
-        if is_buy {
-            let quote_transferred = deposit_non_zero_to_market(
-                &ctx.quote_user_ata,
-                &ctx.quote_market_ata,
-                ctx.user,
-                &ctx.quote_mint,
-                quote_filled,
-            )?;
+    let (taker_amount_filled, taker_amount_deposited) =
+        unsafe { settle_market_order(&ctx, is_buy, base_filled, quote_filled) }?;
 
-            // And receives base.
-            withdraw_non_zero_from_market(
-                &ctx.base_user_ata,
-                &ctx.base_market_ata,
-                &ctx.market_account,
-                &ctx.base_mint,
-                base_filled,
-            )?;
-
-            (quote_filled, quote_transferred)
-        // A sell means taker transfers base to the market.
-        } else {
-            let base_transferred = deposit_non_zero_to_market(
-                &ctx.base_user_ata,
-                &ctx.base_market_ata,
-                ctx.user,
-                &ctx.base_mint,
-                base_filled,
-            )?;
-
-            // And receives quote.
-            withdraw_non_zero_from_market(
-                &ctx.quote_user_ata,
-                &ctx.quote_market_ata,
-                &ctx.market_account,
-                &ctx.quote_mint,
-                quote_filled,
-            )?;
-
-            (base_filled, base_transferred)
-        }
-    };
-
-    // Ensure that the order size matches the exact amount transferred.
+    // makes sure that the order size matches the exact amount transferred
     if taker_amount_filled != taker_amount_deposited {
         return Err(DropsetError::AmountFilledVsTransferredMismatch.into());
     }
@@ -115,4 +74,50 @@ pub unsafe fn process_market_order<'a>(
         event_authority: ctx.event_authority,
         market_account: ctx.market_account,
     })
+}
+
+#[inline(never)]
+unsafe fn settle_market_order(
+    ctx: &MarketOrderContext<'_>,
+    is_buy: bool,
+    base_filled: u64,
+    quote_filled: u64,
+) -> Result<(u64, u64), ProgramError> {
+    if is_buy {
+        let quote_transferred = deposit_non_zero_to_market(
+            &ctx.quote_user_ata,
+            &ctx.quote_market_ata,
+            ctx.user,
+            &ctx.quote_mint,
+            quote_filled,
+        )?;
+
+        withdraw_non_zero_from_market(
+            &ctx.base_user_ata,
+            &ctx.base_market_ata,
+            &ctx.market_account,
+            &ctx.base_mint,
+            base_filled,
+        )?;
+
+        Ok((quote_filled, quote_transferred))
+    } else {
+        let base_transferred = deposit_non_zero_to_market(
+            &ctx.base_user_ata,
+            &ctx.base_market_ata,
+            ctx.user,
+            &ctx.base_mint,
+            base_filled,
+        )?;
+
+        withdraw_non_zero_from_market(
+            &ctx.quote_user_ata,
+            &ctx.quote_market_ata,
+            &ctx.market_account,
+            &ctx.quote_mint,
+            quote_filled,
+        )?;
+
+        Ok((base_filled, base_transferred))
+    }
 }

--- a/program/src/shared/token_utils/market_transfers.rs
+++ b/program/src/shared/token_utils/market_transfers.rs
@@ -36,6 +36,7 @@ use crate::{
 ///   1. `[WRITE]` Market token account (destination)
 ///   2. `[READ]` User account (authority)
 ///   3. `[READ]` Mint account
+#[inline(never)]
 pub unsafe fn deposit_non_zero_to_market<'a, 't>(
     user_ata: &'t TokenAccountView<'a>,
     market_ata: &'t TokenAccountView<'a>,
@@ -105,6 +106,7 @@ pub unsafe fn deposit_non_zero_to_market<'a, 't>(
 ///   1. `[WRITE]` Market token account (source)
 ///   2. `[READ]`  Market account (authority)
 ///   3. `[READ]`  Mint account
+#[inline(never)]
 pub unsafe fn withdraw_non_zero_from_market<'t, 'a>(
     user_ata: &'t TokenAccountView<'a>,
     market_ata: &'t TokenAccountView<'a>,


### PR DESCRIPTION
Fixes cu_market_order crash on fill market order (settle_market_order)

At first I thought it was the fill event sizing, but it ended up being more of a stack problem after the first mid-loop FlushEvents self-CPI

Split the market order settlement work into smaller non-inlined helpers (settle-market-order) so the frame doesn’t get so big. that got rid of the stack access problem

 also kept a few things from debugging:

  - event buffer re-checks len after flushing before writing again
  - flush_events drops the mutable market borrow before the self-CPI
  - FlushEvents and BatchReplace don’t allocate an EventBuffer in the entrypoint if they never use it

cu_market_order passes now (pretty cool to see how this all works i've been spending quite a bit of time learning solana dev stuff)