### PR TITLE
Add stop-services-on-localnet.sh teardown script

### DIFF
--- a/services/stop-services-on-localnet.sh
+++ b/services/stop-services-on-localnet.sh
@@ -4,7 +4,7 @@
 # - the three Dockerized services (faucet, maker-bot, taker-bot)
 # - the backgrounded solana-test-validator
 
-set -uo pipefail
+set -euo pipefail
 
 ROOT="$(git rev-parse --show-toplevel)"
 cd "$ROOT"

--- a/services/stop-services-on-localnet.sh
+++ b/services/stop-services-on-localnet.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Tear down everything started by `run-services-on-localnet.sh`:
+# - the three Dockerized services (faucet, maker-bot, taker-bot)
+# - the backgrounded solana-test-validator
+
+set -uo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+for svc in faucet maker-bot taker-bot; do
+    compose_file="services/$svc/compose.yaml"
+    if [ -f "$compose_file" ]; then
+        echo "Stopping $svc..."
+        docker compose -f "$compose_file" down --remove-orphans
+    fi
+done
+
+if pgrep -x solana-test-validator >/dev/null; then
+    echo "Stopping solana-test-validator..."
+    pkill -x solana-test-validator
+else
+    echo "No solana-test-validator process running."
+fi
+
+echo "Done."


### PR DESCRIPTION
Tears down everything started by `run-services-on-localnet.sh`:
1. The three Dockerized services (faucet, maker-bot, taker-bot)
2. The backgrounded solana-test-validator