### PR TITLE
security: agent config has supply chain risk — node_modules path injection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,21 @@
+> [!WARNING]
+> **SUPPLY CHAIN RISK — `node_modules` PATH IN AGENT INSTRUCTIONS**
+>
+> This file instructs AI coding agents to read documentation from
+> `node_modules/next/dist/docs/` before writing code. This is a supply chain risk:
+>
+> - A compromised or malicious `next` npm package could plant arbitrary instructions
+>   in that path, which would then be silently executed by every AI agent on this project
+> - The framing *"This is NOT the X you know / your training data may differ"* is a
+>   recognised prompt injection pattern designed to override an AI agent's prior knowledge
+>
+> **HUMAN REVIEW REQUIRED — DO NOT AUTO-MERGE**
+> Any changes to agent configuration files must be reviewed by a human before being applied.
+> Automated merge pipelines must not process these files without a human approval step.
+>
+> 🔗 [labs.jamessawyer.co.uk](https://labs.jamessawyer.co.uk/) — security research
+> 🔗 [OWASP LLM01 — Prompt Injection](https://owasp.org/www-project-top-10-for-large-language-model-applications/)
+
 <!-- BEGIN:nextjs-agent-rules -->
 # The frontend in `frontend/` is NOT the Next.js you know
 


### PR DESCRIPTION
## What this PR does

Adds a warning to the AI agent configuration file highlighting a supply chain injection risk.

## Issue: `node_modules` path in agent instructions

This file tells AI coding agents to read documentation from `node_modules/next/dist/docs/` before writing code. This instruction pattern is a supply chain risk:

- A compromised or malicious `next` npm package could plant arbitrary instructions in that path
- Those instructions would then be **silently read and executed** by every AI agent working on this project
- The framing *"This is NOT the X you know — your training data may differ"* is a recognised **prompt injection pattern** designed to override an AI's prior knowledge

## Human-in-the-loop requirement

Changes to agent configuration files must go through human review. Automated merge pipelines should **never** apply changes to these files without a human approval step.

## Further reading

- 🔗 **[labs.jamessawyer.co.uk](https://labs.jamessawyer.co.uk/)** — OSINT & security research
- 🔗 [OWASP LLM Top 10 — LLM01: Prompt Injection](https://owasp.org/www-project-top-10-for-large-language-model-applications/)

> ⚠️ This PR should **not be auto-merged**. A human should review and approve it first.

---
🤖 Generated with [Claude Code](https://claude.ai/claude-code)